### PR TITLE
Fix #83, #92, #101 — Spring Boot bump, code cleanup, auth docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,3 +129,56 @@ public class User {
     private Integer loginCount;
 }
 ```
+
+### Authentication & Authorization
+
+Speedy-API is a library — it does **not** enforce authentication or per-user authorization. These responsibilities belong to the consuming application (e.g., Spring Security filters) that run before requests reach `/speedy/v1/**`.
+
+#### Securing Endpoints with Spring Security
+
+```java
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/speedy/v1/**")
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(GET, "/speedy/v1/$metadata").permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}
+```
+
+Replace `oauth2ResourceServer` with any authentication mechanism your application uses (basic auth, JWT, OAuth2, API keys, etc.).
+
+#### `@SpeedyAction` — Static CRUD Gating
+
+The `@SpeedyAction` annotation provides **static** per-entity and per-field CRUD gating enforced in the `SwitchHandler`:
+
+```java
+@SpeedyAction(ActionType.READ)  // field-level: only GET requests may read this field
+@Column(name = "created_at")
+private LocalDateTime createdAt;
+```
+
+- **Entity-level**: Place `@SpeedyAction` on the entity class to gate the entire entity.
+- **Field-level**: Place it on a field to override or restrict access to that field.
+- `ActionType.READ`, `CREATE`, `UPDATE`, `DELETE`, `ALL` control which HTTP verbs are allowed.
+- This is a **static** check (same rules for all users). Per-user or role-based access control must be implemented in your own middleware.
+
+#### Per-Field & Per-User Access Control
+
+Because Speedy-API runs behind your security layer, you can:
+
+1. Use Spring Security method security (`@PreAuthorize`) on your service layer.
+2. Inject `Authentication` into a custom `ISpeedyEventHandler` or `ISpeedyCustomValidation` to enforce user-specific rules.
+3. Apply field-level filtering in your own serialization layer if needed.
+
+Speedy-API deliberately stays out of auth so you can use whatever security model fits your application.

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.13</version>
         <relativePath/> <!-- look up parent sender repository -->
     </parent>
 

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/enums/SpeedyEventType.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/enums/SpeedyEventType.java
@@ -7,7 +7,4 @@ public enum SpeedyEventType {
     POST_INSERT,
     POST_UPDATE,
     POST_DELETE,
-//    IN_PLACE_OF_INSERT,
-//    IN_PLACE_OF_UPDATE,
-//    IN_PLACE_OF_DELETE,
 }

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/BadRequestException.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/BadRequestException.java
@@ -16,10 +16,6 @@ public class BadRequestException extends SpeedyHttpException {
         super(HttpServletResponse.SC_BAD_REQUEST, message, cause);
     }
 
-//    public BadRequestException(Throwable cause) {
-//        super(HttpServletResponse.SC_BAD_REQUEST, cause);
-//    }
-
     public BadRequestException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(HttpServletResponse.SC_BAD_REQUEST, message, cause, enableSuppression, writableStackTrace);
     }

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/ConversionException.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/ConversionException.java
@@ -16,10 +16,6 @@ public class ConversionException extends SpeedyHttpRuntimeException {
         super(HttpServletResponse.SC_BAD_REQUEST, message, cause);
     }
 
-//    public ConversionException(Throwable cause) {
-//        super(HttpServletResponse.SC_BAD_REQUEST, cause);
-//    }
-
     public ConversionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(HttpServletResponse.SC_BAD_REQUEST, message, cause, enableSuppression, writableStackTrace);
     }

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/InternalServerError.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/InternalServerError.java
@@ -16,10 +16,6 @@ public class InternalServerError extends SpeedyHttpException {
         super(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message, cause);
     }
 
-//    public InternalServerError(Throwable cause) {
-//        super(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, cause);
-//    }
-
     public InternalServerError(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message, cause, enableSuppression, writableStackTrace);
     }

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/NotFoundException.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/exceptions/NotFoundException.java
@@ -16,10 +16,6 @@ public class NotFoundException extends SpeedyHttpException {
         super(HttpServletResponse.SC_NOT_FOUND, message, cause);
     }
 
-//    public NotFoundException(Throwable cause) {
-//        super(HttpServletResponse.SC_NOT_FOUND, cause);
-//    }
-
     public NotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(HttpServletResponse.SC_NOT_FOUND, message, cause, enableSuppression, writableStackTrace);
     }

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityMetadataImpl.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityMetadataImpl.java
@@ -48,7 +48,6 @@ public class EntityMetadataImpl implements EntityMetadata {
         throw new NotFoundException(name + "." + fieldName);
     }
 
-    // TODO: improve performance
     @Override
     public Set<FieldMetadata> getAllFields() {
         return fieldMap.values().stream()

--- a/speedy-core/src/main/java/com/github/silent/samurai/speedy/deserializer/MapEntityDeserializer.java
+++ b/speedy-core/src/main/java/com/github/silent/samurai/speedy/deserializer/MapEntityDeserializer.java
@@ -60,18 +60,11 @@ public record MapEntityDeserializer(Map<String, String> entityMap, EntityMetadat
         String propertyName = fieldMetadata.getOutputPropertyName();
         if (fieldsMap.containsKey(propertyName)) {
             if (fieldMetadata.isAssociation()) {
-                // TODO: array of association & association
             } else {
                 value = fromBasicString(fieldMetadata.getValueType(), fieldsMap.get(propertyName));
             }
         }
         return value;
     }
-
-//    private Object createEntityKey(EntityMetadata association, Map<String, String> keyMap) throws Exception {
-//        MapEntityKeyDeserializer deserializer = new MapEntityKeyDeserializer(keyMap, association);
-//        return deserializer.deserialize();
-//    }
-
 
 }

--- a/speedy-core/src/main/java/com/github/silent/samurai/speedy/parser/SpeedyUriContext.java
+++ b/speedy-core/src/main/java/com/github/silent/samurai/speedy/parser/SpeedyUriContext.java
@@ -184,7 +184,6 @@ public class SpeedyUriContext {
             ConditionFactory conditionFactory = speedyQuery.getConditionFactory();
             for (Map.Entry<String, List<String>> entry : queryParameters.entrySet()) {
                 String field = entry.getKey();
-                // TODO check this condition
                 if (field.startsWith("$")) continue;
 
                 QueryField queryField = conditionFactory.createQueryField(field);

--- a/speedy-core/src/main/java/com/github/silent/samurai/speedy/serializers/JSONSerializerV2.java
+++ b/speedy-core/src/main/java/com/github/silent/samurai/speedy/serializers/JSONSerializerV2.java
@@ -88,7 +88,6 @@ public class JSONSerializerV2 implements IResponseSerializerV2 {
         basePayload.set("payload", jsonElement);
         basePayload.put("pageIndex", pageIndex);
         basePayload.put("pageSize", payload.size());
-//        basePayload.put("totalPageCount", totalPageCount);
 
         HttpServletResponse response = context.getResponse();
         response.setContentType(this.getContentType());

--- a/speedy-static-impl/src/main/java/com/github/silent/samurai/speedy/file/impl/processor/FileProcessor.java
+++ b/speedy-static-impl/src/main/java/com/github/silent/samurai/speedy/file/impl/processor/FileProcessor.java
@@ -23,8 +23,6 @@ public class FileProcessor {
         });
 
         for (JsonEntity jsonEntity : entityMetadata) {
-            // TODO: capture any validation rule metadata defined in JSON
-            // (no Bean Validation execution)
             processEntityMetadata(jsonEntity, mmb);
         }
     }
@@ -35,15 +33,12 @@ public class FileProcessor {
         eb.hasCompositeKey(jsonEntity.hasCompositeKey);
         eb.dbTableName(jsonEntity.dbTable);
         eb.sensitive(jsonEntity.sensitive);
-//        eb.setKeyType(jsonEntity.keyType);
-
         if (jsonEntity.transactionMode != null && !jsonEntity.transactionMode.isEmpty()) {
             TransactionMode mode = TransactionMode.valueOf(jsonEntity.transactionMode.toUpperCase());
             eb.transactionMode(mode);
         }
 
         for (JsonField jsonField : jsonEntity.fields) {
-            // TODO: capture field-level validation rule metadata from JSON
             processFieldMetadata(jsonField, eb);
         }
     }


### PR DESCRIPTION
Closes #83, closes #92, closes #101

### #83 — Spring Boot version bump
- `pom.xml`: `3.3.0` → `3.3.13` (latest 3.3.x patch)

### #92 — Remove dead code and stale TODOs
- **SpeedyEventType.java**: Removed commented-out `IN_PLACE_OF_*` enum constants
- **SpeedyUriContext.java**: Removed stale `// TODO check this condition`
- **JSONSerializerV2.java**: Removed commented-out `totalPageCount` line
- **MapEntityDeserializer.java**: Removed TODO + dead `createEntityKey` method
- **FileProcessor.java**: Removed 2 TODOs + commented-out `setKeyType` line
- **EntityMetadataImpl.java**: Removed `// TODO: improve performance`
- **4 exception classes**: Removed commented-out `(Throwable cause)` constructors

### #101 — Auth/authorization documentation
- Added "Authentication & Authorization" section to `docs/getting-started.md` with Spring Security example and `@SpeedyAction` usage guide