### PR TITLE
[Test] Added validation for incorrect enum usage in `JsonNode2SpeedyV…

### DIFF
--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/io/JsonNode2SpeedyValue.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/io/JsonNode2SpeedyValue.java
@@ -34,10 +34,12 @@ public class JsonNode2SpeedyValue {
             case TEXT:
                 yield fromText(jsonNode.asText());
             case ENUM:
+                if (!jsonNode.isTextual()) throw new BadRequestException("expected string for enum field " + fieldMetadata.getOutputPropertyName());
                 yield fromEnum(jsonNode.asText(), fieldMetadata);
             case INT:
                 yield fromInt(jsonNode.asLong());
             case ENUM_ORD:
+                if (!jsonNode.isNumber()) throw new BadRequestException("expected number for ordinal enum field " + fieldMetadata.getOutputPropertyName());
                 yield fromEnum(jsonNode.asLong(), fieldMetadata);
             case FLOAT:
                 yield fromDouble(jsonNode.asDouble());

--- a/speedy-commons/src/test/java/com/github/silent/samurai/speedy/models/DynamicEnumTest.java
+++ b/speedy-commons/src/test/java/com/github/silent/samurai/speedy/models/DynamicEnumTest.java
@@ -1,0 +1,67 @@
+package com.github.silent.samurai.speedy.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DynamicEnumTest {
+
+    enum Color { RED, GREEN, BLUE }
+
+    private final DynamicEnum colorEnum = DynamicEnum.of(Color.class);
+
+    @Test
+    void fromNameWithValidNameShouldReturnPresent() {
+        assertTrue(colorEnum.fromName("RED").isPresent());
+        assertEquals("RED", colorEnum.fromName("RED").get().name());
+        assertEquals(0, colorEnum.fromName("RED").get().code());
+    }
+
+    @Test
+    void fromNameWithInvalidNameShouldReturnEmpty() {
+        assertTrue(colorEnum.fromName("PURPLE").isEmpty());
+    }
+
+    @Test
+    void fromNameWithNullShouldThrowNullPointerException() {
+        assertThrows(NullPointerException.class, () -> colorEnum.fromName(null));
+    }
+
+    @Test
+    void fromNameIsCaseSensitive() {
+        assertTrue(colorEnum.fromName("red").isEmpty());
+    }
+
+    @Test
+    void fromCodeWithValidCodeShouldReturnPresent() {
+        assertTrue(colorEnum.fromCode(1).isPresent());
+        assertEquals("GREEN", colorEnum.fromCode(1).get().name());
+    }
+
+    @Test
+    void fromCodeWithInvalidCodeShouldReturnEmpty() {
+        assertTrue(colorEnum.fromCode(99).isEmpty());
+    }
+
+    @Test
+    void fromCodeWithNegativeCodeShouldReturnEmpty() {
+        assertTrue(colorEnum.fromCode(-1).isEmpty());
+    }
+
+    @Test
+    void valuesShouldReturnAllVariants() {
+        assertEquals(3, colorEnum.values().size());
+        assertEquals("RED", colorEnum.values().get(0).name());
+        assertEquals("GREEN", colorEnum.values().get(1).name());
+        assertEquals("BLUE", colorEnum.values().get(2).name());
+    }
+
+    @Test
+    void factoryMethodShouldMapAllOrdinalsCorrectly() {
+        for (Color c : Color.values()) {
+            assertTrue(colorEnum.fromName(c.name()).isPresent());
+            assertTrue(colorEnum.fromCode(c.ordinal()).isPresent());
+            assertEquals(c.name(), colorEnum.fromCode(c.ordinal()).get().name());
+        }
+    }
+}

--- a/speedy-commons/src/test/java/com/github/silent/samurai/speedy/models/SpeedyEnumTest.java
+++ b/speedy-commons/src/test/java/com/github/silent/samurai/speedy/models/SpeedyEnumTest.java
@@ -1,0 +1,147 @@
+package com.github.silent.samurai.speedy.models;
+
+import com.github.silent.samurai.speedy.enums.EnumMode;
+import com.github.silent.samurai.speedy.exceptions.BadRequestException;
+import com.github.silent.samurai.speedy.interfaces.FieldMetadata;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpeedyEnumTest {
+
+    enum Status { DRAFT, PENDING, READY }
+
+    private final DynamicEnum statusEnum = DynamicEnum.of(Status.class);
+
+    private FieldMetadata stringModeField() {
+        FieldMetadata fm = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fm.getOperationalEnumMode()).thenReturn(EnumMode.STRING);
+        Mockito.when(fm.getDynamicEnum()).thenReturn(statusEnum);
+        return fm;
+    }
+
+    private FieldMetadata ordinalModeField() {
+        FieldMetadata fm = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fm.getOperationalEnumMode()).thenReturn(EnumMode.ORDINAL);
+        Mockito.when(fm.getDynamicEnum()).thenReturn(statusEnum);
+        return fm;
+    }
+
+    @Test
+    void stringConstructorWithValidNameShouldSucceed() throws BadRequestException {
+        FieldMetadata fm = stringModeField();
+        SpeedyEnum e = new SpeedyEnum("DRAFT", fm);
+        assertEquals("DRAFT", e.asEnum());
+        assertFalse(e.isEmpty());
+    }
+
+    @Test
+    void stringConstructorWithInvalidNameShouldThrowBadRequest() {
+        FieldMetadata fm = stringModeField();
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> new SpeedyEnum("INVALID", fm));
+        assertTrue(ex.getMessage().contains("INVALID"));
+    }
+
+    @Test
+    void stringConstructorWithOrdinalModeShouldThrowBadRequest() {
+        FieldMetadata fm = ordinalModeField();
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> new SpeedyEnum("DRAFT", fm));
+        assertTrue(ex.getMessage().contains("expects STRING mode"));
+    }
+
+    @Test
+    void longConstructorWithValidOrdinalShouldSucceed() throws BadRequestException {
+        FieldMetadata fm = ordinalModeField();
+        SpeedyEnum e = new SpeedyEnum(0L, fm);
+        assertEquals(0L, e.asEnumOrd());
+        assertEquals(0L, e.asInt());
+        assertFalse(e.isEmpty());
+    }
+
+    @Test
+    void longConstructorWithInvalidOrdinalShouldThrowBadRequest() {
+        FieldMetadata fm = ordinalModeField();
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> new SpeedyEnum(99L, fm));
+        assertTrue(ex.getMessage().contains("99"));
+    }
+
+    @Test
+    void longConstructorWithStringModeShouldThrowBadRequest() {
+        FieldMetadata fm = stringModeField();
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> new SpeedyEnum(0L, fm));
+        assertTrue(ex.getMessage().contains("expects ORDINAL mode"));
+    }
+
+    @Test
+    void stringConstructorWithNullValueShouldThrowBadRequest() {
+        FieldMetadata fm = stringModeField();
+        assertThrows(BadRequestException.class, () -> new SpeedyEnum((String) null, fm));
+    }
+
+    @Test
+    void longConstructorWithNullValueShouldThrowBadRequest() {
+        FieldMetadata fm = ordinalModeField();
+        assertThrows(BadRequestException.class, () -> new SpeedyEnum((Long) null, fm));
+    }
+
+    @Test
+    void nullFieldMetadataShouldThrowBadRequest() {
+        assertThrows(BadRequestException.class, () -> new SpeedyEnum("DRAFT", null));
+        assertThrows(BadRequestException.class, () -> new SpeedyEnum(0L, null));
+    }
+
+    @Test
+    void stringEnumShouldHaveCorrectAsEnumAndAsText() throws BadRequestException {
+        FieldMetadata fm = stringModeField();
+        SpeedyEnum e = new SpeedyEnum("READY", fm);
+        assertEquals("READY", e.asEnum());
+        assertEquals("READY", e.asText());
+        assertThrows(Exception.class, e::asInt);
+        assertThrows(Exception.class, e::asEnumOrd);
+    }
+
+    @Test
+    void ordinalEnumShouldHaveCorrectAsEnumOrdAndAsInt() throws BadRequestException {
+        FieldMetadata fm = ordinalModeField();
+        SpeedyEnum e = new SpeedyEnum(1L, fm); // PENDING
+        assertEquals(1L, e.asEnumOrd());
+        assertEquals(1L, e.asInt());
+        assertThrows(Exception.class, e::asText);
+        assertThrows(Exception.class, e::asEnum);
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() throws BadRequestException {
+        FieldMetadata fm = stringModeField();
+        SpeedyEnum e1 = new SpeedyEnum("DRAFT", fm);
+        SpeedyEnum e2 = new SpeedyEnum("DRAFT", fm);
+        SpeedyEnum e3 = new SpeedyEnum("READY", fm);
+
+        assertEquals(e1, e2);
+        assertNotEquals(e1, e3);
+        assertEquals(e1.hashCode(), e2.hashCode());
+    }
+
+    @Test
+    void toStringShouldContainDelegateValue() throws BadRequestException {
+        FieldMetadata fm = stringModeField();
+        SpeedyEnum e = new SpeedyEnum("DRAFT", fm);
+        assertTrue(e.toString().contains("DRAFT"));
+    }
+
+    @Test
+    void eachValidEnumConstantsShouldPassValidation() throws BadRequestException {
+        FieldMetadata stringFm = stringModeField();
+        for (Status s : Status.values()) {
+            SpeedyEnum e = new SpeedyEnum(s.name(), stringFm);
+            assertEquals(s.name(), e.asEnum());
+        }
+
+        FieldMetadata ordinalFm = ordinalModeField();
+        for (Status s : Status.values()) {
+            SpeedyEnum e = new SpeedyEnum((long) s.ordinal(), ordinalFm);
+            assertEquals((long) s.ordinal(), e.asEnumOrd());
+        }
+    }
+}

--- a/speedy-commons/src/test/java/com/github/silent/samurai/speedy/validation/rules/EnumRuleTest.java
+++ b/speedy-commons/src/test/java/com/github/silent/samurai/speedy/validation/rules/EnumRuleTest.java
@@ -1,0 +1,176 @@
+package com.github.silent.samurai.speedy.validation.rules;
+
+import com.github.silent.samurai.speedy.enums.EnumMode;
+import com.github.silent.samurai.speedy.interfaces.FieldMetadata;
+import com.github.silent.samurai.speedy.interfaces.SpeedyValue;
+import com.github.silent.samurai.speedy.models.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnumRuleTest {
+
+    enum Status { DRAFT, PENDING, READY }
+
+    private final DynamicEnum statusEnum = DynamicEnum.of(Status.class);
+    private final EnumRule rule = new EnumRule();
+
+    private FieldMetadata stringEnumField() {
+        FieldMetadata fm = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fm.isEnum()).thenReturn(true);
+        Mockito.when(fm.getOperationalEnumMode()).thenReturn(EnumMode.STRING);
+        Mockito.when(fm.getDynamicEnum()).thenReturn(statusEnum);
+        Mockito.when(fm.getOutputPropertyName()).thenReturn("status");
+        return fm;
+    }
+
+    private FieldMetadata ordinalEnumField() {
+        FieldMetadata fm = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fm.isEnum()).thenReturn(true);
+        Mockito.when(fm.getOperationalEnumMode()).thenReturn(EnumMode.ORDINAL);
+        Mockito.when(fm.getDynamicEnum()).thenReturn(statusEnum);
+        Mockito.when(fm.getOutputPropertyName()).thenReturn("status");
+        return fm;
+    }
+
+    private FieldMetadata nonEnumField() {
+        FieldMetadata fm = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fm.isEnum()).thenReturn(false);
+        Mockito.when(fm.getOutputPropertyName()).thenReturn("name");
+        return fm;
+    }
+
+    private List<String> validate(FieldMetadata fm, SpeedyValue val) {
+        List<String> errors = new ArrayList<>();
+        rule.validate(fm, val, errors);
+        return errors;
+    }
+
+    @Test
+    void stringModeWithValidSpeedyEnumShouldPass() throws Exception {
+        FieldMetadata fm = stringEnumField();
+        SpeedyEnum val = new SpeedyEnum("DRAFT", fm);
+        assertTrue(validate(fm, val).isEmpty());
+    }
+
+    @Test
+    void stringModeWithValidSpeedyTextShouldPass() {
+        FieldMetadata fm = stringEnumField();
+        List<String> errors = validate(fm, new SpeedyText("DRAFT"));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void stringModeWithInvalidSpeedyTextShouldFail() {
+        FieldMetadata fm = stringEnumField();
+        List<String> errors = validate(fm, new SpeedyText("INVALID"));
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("invalid enum value"));
+        assertTrue(errors.get(0).contains("INVALID"));
+    }
+
+    @Test
+    void stringModeWithIntShouldFail() {
+        FieldMetadata fm = stringEnumField();
+        List<String> errors = validate(fm, new SpeedyInt(0L));
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("expects a string enum value"));
+    }
+
+    @Test
+    void stringModeWithDoubleShouldFail() {
+        FieldMetadata fm = stringEnumField();
+        List<String> errors = validate(fm, new SpeedyDouble(1.0));
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("expects a string enum value"));
+    }
+
+    @Test
+    void stringModeWithBooleanShouldFail() {
+        FieldMetadata fm = stringEnumField();
+        List<String> errors = validate(fm, new SpeedyBoolean(true));
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("expects a string enum value"));
+    }
+
+    @Test
+    void ordinalModeWithValidSpeedyEnumShouldPass() throws Exception {
+        FieldMetadata fm = ordinalEnumField();
+        SpeedyEnum val = new SpeedyEnum(0L, fm);
+        assertTrue(validate(fm, val).isEmpty());
+    }
+
+    @Test
+    void ordinalModeWithValidSpeedyIntShouldPass() {
+        FieldMetadata fm = ordinalEnumField();
+        List<String> errors = validate(fm, new SpeedyInt(1L));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void ordinalModeWithInvalidOrdinalShouldFail() {
+        FieldMetadata fm = ordinalEnumField();
+        List<String> errors = validate(fm, new SpeedyInt(99L));
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("invalid enum value"));
+        assertTrue(errors.get(0).contains("99"));
+    }
+
+    @Test
+    void ordinalModeWithTextShouldFail() {
+        FieldMetadata fm = ordinalEnumField();
+        List<String> errors = validate(fm, new SpeedyText("DRAFT"));
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("expects an ordinal enum value"));
+    }
+
+    @Test
+    void ordinalModeWithDoubleShouldFail() {
+        FieldMetadata fm = ordinalEnumField();
+        List<String> errors = validate(fm, new SpeedyDouble(0.0));
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("expects an ordinal enum value"));
+    }
+
+    @Test
+    void nonEnumFieldShouldSkipValidation() {
+        FieldMetadata fm = nonEnumField();
+        List<String> errors = validate(fm, new SpeedyText("hello"));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void nullSpeedyValueShouldSkipValidation() {
+        FieldMetadata fm = stringEnumField();
+        List<String> errors = validate(fm, SpeedyNull.SPEEDY_NULL);
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void stringModeWithNullDynamicEnumShouldPassTypeCheckButNotFailOnMembership() {
+        FieldMetadata fm = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fm.isEnum()).thenReturn(true);
+        Mockito.when(fm.getOperationalEnumMode()).thenReturn(EnumMode.STRING);
+        Mockito.when(fm.getDynamicEnum()).thenReturn(null);
+        Mockito.when(fm.getOutputPropertyName()).thenReturn("status");
+
+        List<String> errors = validate(fm, new SpeedyText("DRAFT"));
+        assertTrue(errors.isEmpty(), "when DynamicEnum is null, membership check is skipped");
+    }
+
+    @Test
+    void ordinalModeWithNullDynamicEnumShouldPassTypeCheckButNotFailOnMembership() {
+        FieldMetadata fm = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fm.isEnum()).thenReturn(true);
+        Mockito.when(fm.getOperationalEnumMode()).thenReturn(EnumMode.ORDINAL);
+        Mockito.when(fm.getDynamicEnum()).thenReturn(null);
+        Mockito.when(fm.getOutputPropertyName()).thenReturn("status");
+
+        List<String> errors = validate(fm, new SpeedyInt(0L));
+        assertTrue(errors.isEmpty(), "when DynamicEnum is null, membership check is skipped");
+    }
+}

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/client/CompanyEnumRejectionTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/client/CompanyEnumRejectionTest.java
@@ -1,0 +1,121 @@
+package com.github.silent.samurai.speedy.client;
+
+import com.github.silent.samurai.speedy.TestApplication;
+import com.github.silent.samurai.speedy.client.test.SpeedyTest;
+import com.github.silent.samurai.speedy.client.test.SpeedyTestResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CompanyEnumRejectionTest {
+
+    SpeedyTest speedyClient;
+    @Autowired
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        speedyClient = SpeedyTest.mockMvc(mvc);
+    }
+
+    private String createCompany(String status) {
+        String nanos = Long.toString(System.nanoTime());
+        String email = "company-rej-" + nanos + "@example.com";
+        speedyClient.create("Company")
+                .field("name", "rejection-test")
+                .field("address", "221B Baker Street")
+                .field("email", email)
+                .field("phone", "+44" + nanos.substring(Math.max(0, nanos.length() - 10)))
+                .field("currency", "GBP")
+                .field("status", status)
+                .execute()
+                .expectOk();
+
+        SpeedyTestResult get = speedyClient.get("Company")
+                .key("email", email)
+                .execute()
+                .expectOk();
+        return get.jsonPath("$.payload[0].id");
+    }
+
+    @Test
+    void createWithInvalidEnumNameShouldReturn400() {
+        speedyClient.create("Company")
+                .field("name", "bad-status-co")
+                .field("address", "Test")
+                .field("email", "bad-status@test.com")
+                .field("phone", "1234567890")
+                .field("currency", "GBP")
+                .field("status", "NOT_A_VALID_STATUS")
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithIntegerForStringEnumShouldReturn400() {
+        speedyClient.create("Company")
+                .field("name", "int-status-co")
+                .field("address", "Test")
+                .field("email", "int-status@test.com")
+                .field("phone", "1234567890")
+                .field("currency", "GBP")
+                .field("status", 1)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithBooleanForStringEnumShouldReturn400() {
+        speedyClient.create("Company")
+                .field("name", "bool-status-co")
+                .field("address", "Test")
+                .field("email", "bool-status@test.com")
+                .field("phone", "1234567890")
+                .field("currency", "GBP")
+                .field("status", true)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithDoubleForStringEnumShouldReturn400() {
+        speedyClient.create("Company")
+                .field("name", "double-status-co")
+                .field("address", "Test")
+                .field("email", "double-status@test.com")
+                .field("phone", "1234567890")
+                .field("currency", "GBP")
+                .field("status", 1.5)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void updateWithInvalidEnumNameShouldReturn400() {
+        String id = createCompany("DRAFT");
+
+        speedyClient.update("Company")
+                .key("id", id)
+                .field("status", "NOT_A_VALID_STATUS")
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void updateWithIntegerForStringEnumShouldReturn400() {
+        String id = createCompany("DRAFT");
+
+        speedyClient.update("Company")
+                .key("id", id)
+                .field("status", 2)
+                .execute()
+                .expectBadRequest();
+    }
+
+}
+

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/client/TaskEnumRejectionTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/client/TaskEnumRejectionTest.java
@@ -1,0 +1,196 @@
+package com.github.silent.samurai.speedy.client;
+
+import com.github.silent.samurai.speedy.TestApplication;
+import com.github.silent.samurai.speedy.client.test.SpeedyTest;
+import com.github.silent.samurai.speedy.client.test.SpeedyTestResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TaskEnumRejectionTest {
+
+    SpeedyTest speedyClient;
+    @Autowired
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        speedyClient = SpeedyTest.mockMvc(mvc);
+    }
+
+    private String createTask(String priority, int difficulty) {
+        SpeedyTestResult result = speedyClient.create("Task")
+                .field("title", "valid-task-" + System.nanoTime())
+                .field("priority", priority)
+                .field("difficulty", difficulty)
+                .execute()
+                .expectOk();
+
+        return result.jsonPath("$.payload[0].id");
+    }
+
+    // ---- STRING enum (priority) rejection ----
+
+    @Test
+    void createWithInvalidPriorityShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "bad-priority")
+                .field("priority", "URGENT")
+                .field("difficulty", 0)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithIntegerForStringEnumPriorityShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "int-priority")
+                .field("priority", 1)
+                .field("difficulty", 0)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithBooleanForStringEnumPriorityShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "bool-priority")
+                .field("priority", true)
+                .field("difficulty", 0)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithDoubleForStringEnumPriorityShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "double-priority")
+                .field("priority", 1.5)
+                .field("difficulty", 0)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void updateWithInvalidPriorityShouldReturn400() {
+        String id = createTask("LOW", 0);
+
+        speedyClient.update("Task")
+                .key("id", id)
+                .field("priority", "URGENT")
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void updateWithIntegerForStringEnumPriorityShouldReturn400() {
+        String id = createTask("LOW", 0);
+
+        speedyClient.update("Task")
+                .key("id", id)
+                .field("priority", 2)
+                .execute()
+                .expectBadRequest();
+    }
+
+    // ---- ORDINAL enum (difficulty) rejection ----
+
+    @Test
+    void createWithInvalidDifficultyOrdinalShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "bad-difficulty")
+                .field("priority", "LOW")
+                .field("difficulty", 99)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithNegativeDifficultyOrdinalShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "neg-difficulty")
+                .field("priority", "LOW")
+                .field("difficulty", -1)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithStringForOrdinalEnumDifficultyShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "str-difficulty")
+                .field("priority", "LOW")
+                .field("difficulty", "99")
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithEnumNameStringForOrdinalEnumShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "name-ordinal")
+                .field("priority", "LOW")
+                .field("difficulty", "EASY")
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithBooleanForOrdinalEnumDifficultyShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "bool-difficulty")
+                .field("priority", "LOW")
+                .field("difficulty", true)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void updateWithInvalidDifficultyOrdinalShouldReturn400() {
+        String id = createTask("LOW", 0);
+
+        speedyClient.update("Task")
+                .key("id", id)
+                .field("difficulty", 99)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void updateWithStringForOrdinalEnumDifficultyShouldReturn400() {
+        String id = createTask("LOW", 0);
+
+        speedyClient.update("Task")
+                .key("id", id)
+                .field("difficulty", "99")
+                .execute()
+                .expectBadRequest();
+    }
+
+    // ---- Combined rejections ----
+
+    @Test
+    void createWithBothInvalidEnumsShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "both-bad")
+                .field("priority", "URGENT")
+                .field("difficulty", 99)
+                .execute()
+                .expectBadRequest();
+    }
+
+    @Test
+    void createWithSwappedTypesShouldReturn400() {
+        speedyClient.create("Task")
+                .field("title", "swapped")
+                .field("priority", 0)
+                .field("difficulty", "LOW")
+                .execute()
+                .expectBadRequest();
+    }
+}


### PR DESCRIPTION
…alue`. Introduced comprehensive unit and integration tests to cover enum validation scenarios, including `CompanyEnumRejectionTest`, `TaskEnumRejectionTest`, `DynamicEnumTest`, `SpeedyEnumTest`, and `EnumRuleTest`.