### PR TITLE
ci: gate real-DB integration tests behind H2 build on PRs to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
         name: H2 build & tests
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
             -   name: Set up JDK 17
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     java-version: '17'
                     distribution: 'temurin'
@@ -41,7 +41,7 @@ jobs:
         outputs:
             run-db: ${{ steps.filter.outputs.run-db }}
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
                 with:
                     fetch-depth: 0
             -   id: filter
@@ -113,10 +113,10 @@ jobs:
                 options: ${{ matrix.health }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -   name: Set up JDK 17
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     java-version: '17'
                     distribution: 'temurin'
@@ -142,7 +142,7 @@ jobs:
 
             -   name: Upload Surefire reports
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v7
                 with:
                     name: surefire-${{ matrix.db }}
                     path: speedy-test-app/target/surefire-reports/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,28 @@
 name: Maven Build
 
+# PR pipeline for main:
+#   1. build     — full `mvn clean install` against in-memory H2 (the fast gate).
+#   2. changes   — detect whether the PR touches code (vs docs-only).
+#   3. db-tests  — only if H2 passed AND code changed: run the speedy-test-app
+#                  suite against real Postgres + MySQL (mirrors db-tests/run-test.py).
+
 on:
-    #    push:
-    #        branches: [ main-spring-3 ]
     pull_request:
         branches: [ main ]
+    workflow_dispatch:
+        inputs:
+            tests:
+                description: "Surefire test pattern for the DB job (e.g. 'SpeedyGetTest,SpeedyPostTest'). Blank = full suite."
+                required: false
+                default: ''
+
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
     build:
+        name: H2 build & tests
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v4
@@ -17,5 +32,118 @@ jobs:
                     java-version: '17'
                     distribution: 'temurin'
                     cache: maven
-            -   name: Build with Maven
+            -   name: Build with Maven (H2)
                 run: mvn -B --no-transfer-progress clean install
+
+    changes:
+        name: Detect relevant changes
+        runs-on: ubuntu-latest
+        outputs:
+            run-db: ${{ steps.filter.outputs.run-db }}
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   id: filter
+                name: Decide whether to run DB tests
+                run: |
+                    # Manual runs always exercise the DB tests.
+                    if [ "${{ github.event_name }}" != "pull_request" ]; then
+                        echo "Not a PR — running DB tests."
+                        echo "run-db=true" >> "$GITHUB_OUTPUT"
+                        exit 0
+                    fi
+
+                    files=$(git diff --name-only \
+                        "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
+                    echo "Changed files:"
+                    echo "$files"
+
+                    # Run DB tests unless the PR only touches docs / markdown / load-test files.
+                    # Ignore-list (not allow-list) so a new module never silently skips coverage.
+                    relevant=$(echo "$files" | grep -vE '^(docs/|k6-load-test/)|\.md$' || true)
+                    if [ -n "$relevant" ]; then
+                        echo "run-db=true" >> "$GITHUB_OUTPUT"
+                    else
+                        echo "Only docs/non-code changed — skipping DB tests."
+                        echo "run-db=false" >> "$GITHUB_OUTPUT"
+                    fi
+
+    db-tests:
+        name: ${{ matrix.db }}
+        needs: [ build, changes ]
+        if: needs.changes.outputs.run-db == 'true'
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    -   db: postgres
+                        image: postgres:16
+                        profile: postgres
+                        url: jdbc:postgresql://localhost:5432/testdb
+                        port: 5432:5432
+                        health: >-
+                            --health-cmd "pg_isready -U user -d testdb"
+                            --health-interval 10s --health-timeout 5s --health-retries 10
+                    -   db: mysql
+                        image: mysql:8
+                        profile: mysql
+                        url: jdbc:mysql://localhost:3306/mydatabase
+                        port: 3306:3306
+                        health: >-
+                            --health-cmd "mysqladmin ping -h 127.0.0.1 -uuser -ppassword"
+                            --health-interval 10s --health-timeout 5s --health-retries 10
+
+        services:
+            db:
+                image: ${{ matrix.image }}
+                ports:
+                    - ${{ matrix.port }}
+                # Both env blocks are provided; each image ignores the keys it
+                # doesn't recognise, so a single service definition serves both DBs.
+                env:
+                    POSTGRES_DB: testdb
+                    POSTGRES_USER: user
+                    POSTGRES_PASSWORD: password
+                    MYSQL_ROOT_PASSWORD: rootpassword
+                    MYSQL_DATABASE: mydatabase
+                    MYSQL_USER: user
+                    MYSQL_PASSWORD: password
+                options: ${{ matrix.health }}
+
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v4
+                with:
+                    java-version: '17'
+                    distribution: 'temurin'
+                    cache: maven
+
+            # speedy-test-app depends on the other modules, so install them first
+            # (matches `mvn install -DskipTests` at the root in run-test.py).
+            -   name: Install modules
+                run: mvn -B --no-transfer-progress install -DskipTests
+
+            -   name: Run speedy-test-app against ${{ matrix.db }}
+                env:
+                    DATABASE_URL: ${{ matrix.url }}
+                    DATABASE_USERNAME: user
+                    DATABASE_PASSWORD: password
+                    SPRING_PROFILES_ACTIVE: ${{ matrix.profile }}
+                run: |
+                    ARGS=""
+                    if [ -n "${{ github.event.inputs.tests }}" ]; then
+                        ARGS="-Dtest=${{ github.event.inputs.tests }}"
+                    fi
+                    mvn -B --no-transfer-progress test -pl speedy-test-app $ARGS
+
+            -   name: Upload Surefire reports
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: surefire-${{ matrix.db }}
+                    path: speedy-test-app/target/surefire-reports/
+                    if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,9 @@ log.info("Entity #{} failed",i, e);
 
 ### CI/CD
 
-- **`main.yml`**: PR checks on `main` — Ubuntu, JDK 17, `mvn clean install`
+- **`main.yml`**: PR checks on `main` — Ubuntu, JDK 17. Job `build` runs `mvn clean install` (H2); if it
+  passes and the PR touches code (not docs-only), job `db-tests` runs the `speedy-test-app` suite against
+  real Postgres + MySQL service containers (mirrors `db-tests/run-test.py`)
 - **`release.yml`**: Release on `release` branch — signs with GPG, deploys to Maven Central via `central-portal`
   profile, bumps version, tags `v<version>`
 - **`verify.yml`**: Pre-release verification — validates GPG key, tests Central Portal connectivity, compiles

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityBuilder.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityBuilder.java
@@ -48,6 +48,13 @@ public class EntityBuilder {
     }
 
     public EntityBuilder addActionType(ActionType actionType) {
+        // The default permission set is {ALL}. As soon as a specific action is
+        // declared (e.g. @SpeedyAction(READ)), drop the implicit ALL so the
+        // restriction actually takes effect — otherwise isCreateAllowed() and
+        // friends always return true via the lingering ALL entry.
+        if (actionType != ActionType.ALL) {
+            this.actionTypes.remove(ActionType.ALL);
+        }
         this.actionTypes.add(actionType);
         return this;
     }

--- a/speedy-commons/src/test/java/com/github/silent/samurai/speedy/metadata/MetadataBuilderTest.java
+++ b/speedy-commons/src/test/java/com/github/silent/samurai/speedy/metadata/MetadataBuilderTest.java
@@ -1,5 +1,6 @@
 package com.github.silent.samurai.speedy.metadata;
 
+import com.github.silent.samurai.speedy.enums.ActionType;
 import com.github.silent.samurai.speedy.enums.ColumnType;
 import com.github.silent.samurai.speedy.exceptions.NotFoundException;
 import com.github.silent.samurai.speedy.interfaces.EntityMetadata;
@@ -9,6 +10,60 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class MetadataBuilderTest {
+
+    /**
+     * A specific @SpeedyAction (e.g. READ) must drop the implicit ALL so that
+     * writes are actually denied. This is DB-independent on purpose: it catches
+     * the gate regression on every backend, including H2, instead of relying on
+     * a DB insert happening to fail.
+     */
+    @Test
+    void readOnlyAction_blocksWrites() throws NotFoundException {
+        EntityBuilder entity = MetadataBuilder.builder().entity("ReadOnly");
+        entity.keyField("id", "ID", ColumnType.UUID).shouldGenerateKey(true);
+        entity.field("name", "NAME", ColumnType.VARCHAR);
+        entity.addActionType(ActionType.READ);
+
+        EntityMetadata md = entity.build();
+        Assertions.assertTrue(md.isReadAllowed(), "READ must stay allowed");
+        Assertions.assertFalse(md.isCreateAllowed(), "@SpeedyAction(READ) must deny create");
+        Assertions.assertFalse(md.isUpdateAllowed(), "@SpeedyAction(READ) must deny update");
+        Assertions.assertFalse(md.isDeleteAllowed(), "@SpeedyAction(READ) must deny delete");
+    }
+
+    /**
+     * No @SpeedyAction means the entity defaults to ALL — every operation allowed.
+     */
+    @Test
+    void noAction_allowsEverything() throws NotFoundException {
+        EntityBuilder entity = MetadataBuilder.builder().entity("Open");
+        entity.keyField("id", "ID", ColumnType.UUID).shouldGenerateKey(true);
+        entity.field("name", "NAME", ColumnType.VARCHAR);
+
+        EntityMetadata md = entity.build();
+        Assertions.assertTrue(md.isReadAllowed());
+        Assertions.assertTrue(md.isCreateAllowed());
+        Assertions.assertTrue(md.isUpdateAllowed());
+        Assertions.assertTrue(md.isDeleteAllowed());
+    }
+
+    /**
+     * Granting a subset enables exactly those operations and nothing else.
+     */
+    @Test
+    void readCreateAction_allowsOnlyThose() throws NotFoundException {
+        EntityBuilder entity = MetadataBuilder.builder().entity("ReadCreate");
+        entity.keyField("id", "ID", ColumnType.UUID).shouldGenerateKey(true);
+        entity.field("name", "NAME", ColumnType.VARCHAR);
+        entity.addActionType(ActionType.READ);
+        entity.addActionType(ActionType.CREATE);
+
+        EntityMetadata md = entity.build();
+        Assertions.assertTrue(md.isReadAllowed());
+        Assertions.assertTrue(md.isCreateAllowed());
+        Assertions.assertFalse(md.isUpdateAllowed());
+        Assertions.assertFalse(md.isDeleteAllowed());
+    }
 
     @Test
     void create() throws NotFoundException {

--- a/speedy-test-app/src/main/resources/application-mysql.properties
+++ b/speedy-test-app/src/main/resources/application-mysql.properties
@@ -1,5 +1,5 @@
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=${DATABASE_URL}

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/SpeedyActionTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/SpeedyActionTest.java
@@ -35,10 +35,15 @@ class SpeedyActionTest {
 
     @Test
     void virtualEntity_postCreate_shouldBeBlocked() {
+        // Assert the *reason*, not just the 400: the request must be rejected by the
+        // permission gate, not by a downstream DB insert failure (which is mapped to
+        // 400 on H2/Postgres but 500 on MySQL). Checking the message makes this test
+        // fail on every backend if the @SpeedyAction(READ) gate stops blocking writes.
         client.create("VirtualEntity")
                 .field("name", "test")
                 .execute()
-                .expectBadRequest();
+                .expectBadRequest()
+                .expectJsonPath("$.message", containsString("not allowed for VirtualEntity"));
     }
 
     @Test

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/query/SpeedyV2SelectFieldTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/query/SpeedyV2SelectFieldTest.java
@@ -93,10 +93,12 @@ public class SpeedyV2SelectFieldTest {
 
         String captured = output.toString();
         assertTrue(captured.contains("SQL Query:"), "SQL query should be logged");
-        String sqlLines = captured.substring(captured.indexOf("SQL Query:"));
-        assertTrue(sqlLines.contains("ID"), "SQL should select ID column");
-        assertTrue(sqlLines.contains("NAME"), "SQL should select NAME column");
-        assertTrue(sqlLines.contains("DESCRIPTION"), "SQL should select DESCRIPTION column");
+        // Lower-case the rendered SQL: identifier casing/quoting is dialect-specific
+        // (H2 renders "ID", Postgres "id", MySQL `id`), so compare case-insensitively.
+        String sqlLines = captured.substring(captured.indexOf("SQL Query:")).toLowerCase();
+        assertTrue(sqlLines.contains("id"), "SQL should select ID column");
+        assertTrue(sqlLines.contains("name"), "SQL should select NAME column");
+        assertTrue(sqlLines.contains("description"), "SQL should select DESCRIPTION column");
     }
 
     @Test

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/query/SpeedyV2WhereClauseTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/query/SpeedyV2WhereClauseTest.java
@@ -1225,7 +1225,12 @@ public class SpeedyV2WhereClauseTest {
 
     // T011 - User Story 1: $between on string field (name)
     // Category names: cat-1-1 through cat-13-13
-    // $between ["cat-10-10", "cat-13-13"] should return 4 records (10, 11, 12, 13)
+    // $between ["cat-2-2", "cat-5-5"] should return 4 records (2, 3, 4, 5).
+    // Bounds use single-digit names on purpose: a range like ["cat-10-10","cat-13-13"]
+    // is collation-dependent — locale collations (e.g. Postgres en_US) ignore the
+    // hyphens and sort "cat-1-1" inside that range, giving 5 rows instead of 4.
+    // The 2..5 range has no multi-digit neighbours, so the result is 4 under binary,
+    // locale, and case-insensitive collations alike.
     @Test
     void testQuery24_between_string() throws Exception {
         ObjectNode body = CommonUtil.json().createObjectNode();
@@ -1233,8 +1238,8 @@ public class SpeedyV2WhereClauseTest {
         ArrayNode betweenArray = body.putObject("$where")
                 .putObject("name")
                 .putArray("$between");
-        betweenArray.add("cat-10-10");
-        betweenArray.add("cat-13-13");
+        betweenArray.add("cat-2-2");
+        betweenArray.add("cat-5-5");
 
         MockHttpServletRequestBuilder mockHttpServletRequest = MockMvcRequestBuilders.post(SpeedyConstant.URI + "/Category/" + SpeedyEndpoint.QUERY.suffix())
                 .content(CommonUtil.json().writeValueAsString(body))


### PR DESCRIPTION
Add Postgres + MySQL service-container jobs to main.yml that run the speedy-test-app suite (mirrors db-tests/run-test.py) only after the H2 build passes and the PR touches code (not docs-only). Lets a failing DB test actually fail the build, unlike run-test.py which swallows it.