### PR TITLE
Add @SpeedyAssociation for scalar FK columns without a JPA relationship

### DIFF
--- a/docs/speedy-jpa.md
+++ b/docs/speedy-jpa.md
@@ -125,6 +125,52 @@ public class PublicEntity {
 }
 ```
 
+### Speedy Association
+
+By default Speedy only discovers associations from real JPA relationships (`@ManyToOne`/`@OneToOne`).
+If a foreign key has to stay a plain scalar column — for example a `UUID` field on a shared or
+legacy entity that can't be remapped to an object reference — annotate it with `@SpeedyAssociation`
+to wire it into the metamodel as an association anyway. It always binds to the target entity's
+primary key, exactly like `@ManyToOne` does.
+
+```java
+@Table(name = "entity")
+@Entity
+public class Entity {
+
+    @Column(name = "target_id")
+    @SpeedyAssociation(Target.class)
+    private UUID target;
+}
+```
+
+The target entity is given as exactly one of `value()` (its JPA entity class) or `entity()` (its
+Speedy entity name as a `String`) — use the latter when the target class isn't available to
+reference directly, e.g. across module boundaries:
+
+```java
+    @Column(name = "target_id")
+    @SpeedyAssociation(entity = "Target")
+    private UUID target;
+```
+
+Specifying both, or neither, fails fast at metamodel build time.
+
+The scalar field's own declared Java type doesn't need to match the target's primary key type —
+the actual read/write conversion is driven entirely by the target key field's type, so this works
+identically against `UUID`, `String`, or numeric (e.g. `Long` `IDENTITY`) primary keys. Like
+`@ManyToOne`, it only ever binds to the target's *first* key field
+(`EntityBuilder#keyFields().iterator().next()`), so a composite-key target isn't fully addressable
+this way — this is a pre-existing limitation shared with every other association kind, not
+specific to `@SpeedyAssociation`.
+
+Once annotated, the field behaves exactly like a `@ManyToOne` association: it gains `$expand`
+support, `$filter` navigation through the association (e.g. `target.name`), and is serialized as
+a keys-only reference object (or fully expanded object with `$expand`) rather than a bare scalar.
+This also means write payloads must use the nested-object shape (`{"target": {"id": "<uuid>"}}`)
+instead of a bare scalar value — a plain `UUID` value is rejected, same as for any other
+association field.
+
 ### Speedy Sensitive
 
 Prevent fields from being used in `$` field references in queries.

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/annotations/SpeedyAssociation.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/annotations/SpeedyAssociation.java
@@ -1,0 +1,25 @@
+package com.github.silent.samurai.speedy.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/// Declares a scalar field as a Speedy association without a native JPA relationship
+/// (`@ManyToOne`/`@OneToOne`) backing it — e.g. a plain `UUID` column that logically
+/// references another entity's primary key but can't be remapped to an object reference.
+/// Always binds to the target entity's primary key, mirroring how `@ManyToOne` is resolved.
+///
+/// The target entity is given as exactly one of {@link #value()} (its JPA entity class) or
+/// {@link #entity()} (its Speedy entity name) — use the latter when the target class isn't
+/// available to reference directly, e.g. across module boundaries.
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SpeedyAssociation {
+
+    /// The target JPA entity class. Mutually exclusive with {@link #entity()}.
+    Class<?> value() default Void.class;
+
+    /// The target Speedy entity name. Mutually exclusive with {@link #value()}.
+    String entity() default "";
+}

--- a/speedy-mp-jpa/src/main/java/com/github/silent/samurai/speedy/jpa/impl/processors/JpaMetaModelProcessorV2.java
+++ b/speedy-mp-jpa/src/main/java/com/github/silent/samurai/speedy/jpa/impl/processors/JpaMetaModelProcessorV2.java
@@ -515,18 +515,28 @@ public class JpaMetaModelProcessorV2 implements MetaModelProcessor {
 
             for (FieldBuilder fieldBuilder : entity.fields()) {
                 Attribute<?, ?> attribute = attributeMap.get(fieldBuilder.getOutputPropertyName());
-                if (!attribute.isAssociation()) {
-                    continue;
-                }
                 Member member = attribute.getJavaMember();
                 Field field = findReflectionField(attribute, entityType.getJavaType());
 
+                SpeedyAssociation manualAssociation = AnnotationUtils.getAnnotation(field, SpeedyAssociation.class);
+                if (!attribute.isAssociation() && manualAssociation == null) {
+                    continue;
+                }
+
                 String outputName = findOutputName(field, member);
 
-                Class<?> fieldType = field.getType();
-                if (attribute.isCollection()) {
-                    fieldType = resolveGenericFieldType(field);
+                if (manualAssociation != null) {
+                    String associatedEntityName = resolveManualAssociationEntityName(manualAssociation, entityType, member);
+                    if (!builder.hasEntity(associatedEntityName)) {
+                        throw new RuntimeException(String.format("association not found %s.%s for %s", entityType.getName(), member.getName(), associatedEntityName));
+                    }
+                    EntityBuilder associatedEntity = builder.ref(associatedEntityName);
+                    KeyFieldBuilder keyFieldBuilder = associatedEntity.keyFields().iterator().next();
+                    fieldBuilder.associateWith(keyFieldBuilder);
+                    continue;
                 }
+
+                Class<?> fieldType = attribute.isCollection() ? resolveGenericFieldType(field) : field.getType();
 
                 EntityType<?> associatedEntityType = entityManagerFactory.getMetamodel().entity(fieldType);
                 if (!builder.hasEntity(associatedEntityType.getName())) {
@@ -552,5 +562,21 @@ public class JpaMetaModelProcessorV2 implements MetaModelProcessor {
                 }
             }
         }
+    }
+
+    /// Resolves the target entity name for a {@link SpeedyAssociation}, which accepts exactly one
+    /// of {@code value()} (a JPA entity class) or {@code entity()} (a Speedy entity name directly).
+    String resolveManualAssociationEntityName(SpeedyAssociation manualAssociation, EntityType<?> entityType, Member member) {
+        boolean hasClass = manualAssociation.value() != Void.class;
+        boolean hasEntityName = !manualAssociation.entity().isBlank();
+        if (hasClass == hasEntityName) {
+            throw new RuntimeException(String.format(
+                    "@SpeedyAssociation on %s.%s must specify exactly one of value() or entity()",
+                    entityType.getName(), member.getName()));
+        }
+        if (hasClass) {
+            return entityManagerFactory.getMetamodel().entity(manualAssociation.value()).getName();
+        }
+        return manualAssociation.entity();
     }
 }

--- a/speedy-qp-jooq/src/main/java/com/github/silent/samurai/speedy/jooq/impl/query/JooqToJooqSql.java
+++ b/speedy-qp-jooq/src/main/java/com/github/silent/samurai/speedy/jooq/impl/query/JooqToJooqSql.java
@@ -30,10 +30,11 @@ public class JooqToJooqSql {
         FieldMetadata associationFieldMetadata = fieldMetadata.getAssociatedFieldMetadata();
 
         Field<Object> field = JooqUtil.getColumn(associationFieldMetadata, dslContext.dialect());
+        Table<Record> table = JooqUtil.getTable(associationMetadata, dslContext.dialect());
 
         SelectConditionStep<Record> query = dslContext
                 .select()
-                .from(associationMetadata.getDbTableName())
+                .from(table)
                 .where(field.eq(fkColumnValue));
 
         LOGGER.info("expand query: {} ", query);

--- a/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/ScalarFkEntity.java
+++ b/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/ScalarFkEntity.java
@@ -1,0 +1,51 @@
+package com.github.silent.samurai.speedy.entity;
+
+import com.github.silent.samurai.speedy.annotations.SpeedyAssociation;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+// Exercises @SpeedyAssociation, the manual-association path for scalar fields JPA itself
+// doesn't recognize as a relationship (no @ManyToOne/@JoinColumn). Each field below targets a
+// primary key of a different type/generation strategy, since the FK's actual read/write
+// conversion is driven entirely by the *target* key field's type (JooqUtil.conversionField),
+// not by this entity's own declared Java type:
+//   - ref / refByName -> PkUuidTest.id       (java.util.UUID, GenerationType.UUID)
+//   - catRef           -> Category.id         (String, GenerationType.UUID)
+//   - numRef            -> AutoGenIdentityEntity.id (Long, GenerationType.IDENTITY)
+@Getter
+@Setter
+@Table(name = "SCALAR_FK_ENTITY")
+@Entity
+public class ScalarFkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    protected UUID id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "ref_id", nullable = true)
+    @SpeedyAssociation(PkUuidTest.class)
+    private UUID ref;
+
+    // Same target, resolved by Speedy entity name instead of Java class.
+    @Column(name = "ref_by_name_id", nullable = true)
+    @SpeedyAssociation(entity = "PkUuidTest")
+    private UUID refByName;
+
+    // Targets a String-typed, GenerationType.UUID primary key.
+    @Column(name = "cat_ref_id", nullable = true)
+    @SpeedyAssociation(Category.class)
+    private String catRef;
+
+    // Targets a numeric, DB-assigned (IDENTITY) primary key.
+    @Column(name = "num_ref_id", nullable = true)
+    @SpeedyAssociation(AutoGenIdentityEntity.class)
+    private Long numRef;
+
+}

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/ScalarFkAssociationTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/ScalarFkAssociationTest.java
@@ -1,0 +1,245 @@
+package com.github.silent.samurai.speedy.entity;
+
+import com.github.silent.samurai.speedy.SpeedyFactory;
+import com.github.silent.samurai.speedy.TestApplication;
+import com.github.silent.samurai.speedy.client.test.SpeedyTest;
+import com.github.silent.samurai.speedy.client.test.SpeedyTestResult;
+import com.github.silent.samurai.speedy.exceptions.NotFoundException;
+import com.github.silent.samurai.speedy.interfaces.metadata.FieldMetadata;
+import com.github.silent.samurai.speedy.interfaces.metadata.MetaModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.condition;
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.eq;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+// Covers ScalarFkEntity's plain scalar columns (no @ManyToOne/@JoinColumn) wired as Speedy
+// associations purely via @SpeedyAssociation: by target class (ref), by target entity name
+// (refByName), and against target primary keys of different types/generation strategies
+// (catRef -> Category.id: String/GenerationType.UUID; numRef -> AutoGenIdentityEntity.id:
+// Long/GenerationType.IDENTITY) to confirm read/write conversion isn't UUID-specific.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ScalarFkAssociationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private SpeedyFactory speedyFactory;
+
+    private SpeedyTest speedyClient;
+
+    @BeforeEach
+    void setUp() {
+        speedyClient = SpeedyTest.mockMvc(mvc);
+    }
+
+    private String createTarget() {
+        return speedyClient.create("PkUuidTest")
+                .field("name", "target-" + UUID.randomUUID())
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+    }
+
+    // Category.id: String, GenerationType.UUID.
+    private String createCategoryTarget() {
+        return speedyClient.create("Category")
+                .field("name", "cat-" + UUID.randomUUID())
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+    }
+
+    // AutoGenIdentityEntity.id: Long, GenerationType.IDENTITY (DB-assigned).
+    private long createIdentityTarget() {
+        Object rawId = speedyClient.create("AutoGenIdentityEntity")
+                .field("name", "num-target-" + UUID.randomUUID())
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id", Object.class);
+        return Long.parseLong(String.valueOf(rawId));
+    }
+
+    @Test
+    void metamodel_scalarUuidField_isWiredAsAssociation() throws NotFoundException {
+        MetaModel metaModel = speedyFactory.getMetaModel();
+        FieldMetadata field = metaModel.findFieldMetadata("ScalarFkEntity", "ref");
+
+        assertThat(field.isAssociation(), is(true));
+        assertThat(field.getAssociationMetadata().getName(), is("PkUuidTest"));
+        assertThat(field.getAssociatedFieldMetadata().getOutputPropertyName(), is("id"));
+    }
+
+    @Test
+    void metamodel_entityNameForm_isWiredAsAssociation() throws NotFoundException {
+        MetaModel metaModel = speedyFactory.getMetaModel();
+        FieldMetadata field = metaModel.findFieldMetadata("ScalarFkEntity", "refByName");
+
+        assertThat(field.isAssociation(), is(true));
+        assertThat(field.getAssociationMetadata().getName(), is("PkUuidTest"));
+        assertThat(field.getAssociatedFieldMetadata().getOutputPropertyName(), is("id"));
+    }
+
+    @Test
+    void create_withEntityNameFormField_roundTripsAsKeysOnlyReference() {
+        String targetId = createTarget();
+
+        String sourceId = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("refByName.id", targetId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.get("ScalarFkEntity")
+                .key("id", sourceId)
+                .execute()
+                .expectOk()
+                .expectJsonPath("$.payload[0].refByName.id", targetId);
+    }
+
+    @Test
+    void metamodel_stringPkTargetField_isWiredAsAssociation() throws NotFoundException {
+        // Category.id is a String primary key (GenerationType.UUID), not java.util.UUID —
+        // confirms association resolution isn't tied to the target's key being a UUID type.
+        MetaModel metaModel = speedyFactory.getMetaModel();
+        FieldMetadata field = metaModel.findFieldMetadata("ScalarFkEntity", "catRef");
+
+        assertThat(field.isAssociation(), is(true));
+        assertThat(field.getAssociationMetadata().getName(), is("Category"));
+        assertThat(field.getAssociatedFieldMetadata().getOutputPropertyName(), is("id"));
+    }
+
+    @Test
+    void metamodel_numericPkTargetField_isWiredAsAssociation() throws NotFoundException {
+        // AutoGenIdentityEntity.id is a DB-assigned Long primary key.
+        MetaModel metaModel = speedyFactory.getMetaModel();
+        FieldMetadata field = metaModel.findFieldMetadata("ScalarFkEntity", "numRef");
+
+        assertThat(field.isAssociation(), is(true));
+        assertThat(field.getAssociationMetadata().getName(), is("AutoGenIdentityEntity"));
+        assertThat(field.getAssociatedFieldMetadata().getOutputPropertyName(), is("id"));
+    }
+
+    @Test
+    void create_withStringPkTarget_roundTrips() {
+        String targetId = createCategoryTarget();
+
+        String sourceId = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("catRef.id", targetId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.get("ScalarFkEntity")
+                .key("id", sourceId)
+                .execute()
+                .expectOk()
+                .expectJsonPath("$.payload[0].catRef.id", targetId);
+    }
+
+    @Test
+    void create_withNumericPkTarget_roundTrips() {
+        long targetId = createIdentityTarget();
+
+        String sourceId = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("numRef.id", targetId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        Object actual = speedyClient.get("ScalarFkEntity")
+                .key("id", sourceId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].numRef.id", Object.class);
+
+        assertThat(Long.parseLong(String.valueOf(actual)), is(targetId));
+    }
+
+    @Test
+    void create_withNestedObjectPayload_roundTripsAsKeysOnlyReference() {
+        String targetId = createTarget();
+
+        SpeedyTestResult createResponse = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("ref.id", targetId)
+                .execute()
+                .expectOk();
+
+        String sourceId = createResponse.jsonPath("$.payload[0].id");
+
+        speedyClient.get("ScalarFkEntity")
+                .key("id", sourceId)
+                .execute()
+                .expectOk()
+                .expectJsonPath("$.payload[0].ref.id", targetId)
+                .expectJsonPathDoesNotExist("$.payload[0].ref.name");
+    }
+
+    @Test
+    void create_withBareScalarPayload_isRejected() {
+        // Association fields are rejected as soon as the request body is deserialized
+        // (StructureToSpeedy), before AssociationRule even runs.
+        speedyClient.create("ScalarFkEntity")
+                .field("name", "bad-" + UUID.randomUUID())
+                .field("ref", UUID.randomUUID().toString())
+                .execute()
+                .expectBadRequest()
+                .expectJsonPath("$.message", containsString("must be an object"));
+    }
+
+    @Test
+    void query_withExpand_returnsFullyNestedObject() {
+        // $expand is only honored on the $query path (DefaultQueryProcessor.executeManyWithCount);
+        // GET-by-key (fetchByKey) hardcodes an empty expand set regardless of association kind.
+        // Per ExpansionPathTracker, $expand entries are matched by the associated entity's name
+        // ("PkUuidTest"), not the field's output property name ("ref") — same as every other
+        // association in this codebase (see SpeedyV2ExpandTest).
+        String targetId = createTarget();
+
+        String sourceId = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("ref.id", targetId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.query("ScalarFkEntity")
+                .where(condition("id", eq(sourceId)))
+                .expand("PkUuidTest")
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].ref.name");
+    }
+
+    @Test
+    void query_filterByAssociatedField_navigatesThroughAssociation() {
+        String targetId = createTarget();
+
+        speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("ref.id", targetId)
+                .execute()
+                .expectOk();
+
+        speedyClient.query("ScalarFkEntity")
+                .where(condition("ref.id", eq(targetId)))
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].id");
+    }
+}


### PR DESCRIPTION
## Summary
- New `@SpeedyAssociation` field annotation lets a plain scalar column (e.g. a raw `UUID` FK that can't be remapped to `@ManyToOne`/`@JoinColumn`) be wired into the Speedy metamodel as a full association: `$expand`, `$filter` navigation, and nested-object serialization all work the same as for a real `@ManyToOne` field.
- Target entity can be given as a JPA class (`@SpeedyAssociation(Target.class)`) or as a Speedy entity name (`@SpeedyAssociation(entity = "Target")`) for cases where the class isn't directly referenceable; specifying both or neither fails fast at metamodel build time.
- Resolution reuses the existing `FieldBuilder.associateWith(...)` path, so it works identically regardless of the target's primary key type (verified against `UUID`, `String`/`GenerationType.UUID`, and `Long`/`GenerationType.IDENTITY` targets).
- `MetaModelVerifier`'s existing generic association check already covers both resolution paths — no changes needed there.
- Documented in `docs/speedy-jpa.md` under a new "Speedy Association" section, including the shared (pre-existing) limitation that composite-key targets aren't fully addressable, same as `@ManyToOne`.
- **Bug fix**: `JooqToJooqSql.findByFK()` (the `$expand` FK-resolution query, shared by every association kind) built its `FROM` clause from the raw `EntityMetadata.getDbTableName()` string instead of going through `JooqUtil.getTable()`'s identifier transform/quoting like every other query path. Harmless on H2, but on MySQL CI it produced an unquoted, untransformed table name that didn't match the real table — surfaced as `Table 'PK_UUID_TEST' doesn't exist` the first time `$expand` targeted an uppercase-named entity. Not specific to this feature; affects any `$expand` (`@ManyToOne`/`@OneToOne` too) whose target table name isn't already lowercase.

## Test plan
- [x] `speedy-commons` and `speedy-mp-jpa` unit suites pass
- [x] New `ScalarFkAssociationTest` (11 cases): metadata wiring, nested-object create/read round-trip, `$expand`, `$filter` navigation, bare-scalar payload rejection — across `Class`-based and `String`-based target resolution, and `UUID`/`String`/`Long` primary key targets
- [x] Full `speedy-test-app` regression suite (all ~120 classes): 679 tests, 0 failures, 0 errors (1 pre-existing unrelated skip) — reran after the `$expand` FROM-clause fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)