### PR TITLE
Let association filters resolve by target entity name, not just field name

### DIFF
--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/models/ExpansionPathTracker.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/models/ExpansionPathTracker.java
@@ -4,6 +4,7 @@ import com.github.silent.samurai.speedy.interfaces.metadata.EntityMetadata;
 
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,12 +39,18 @@ public class ExpansionPathTracker {
 
     private final Deque<EntityMetadata> currentPath = new LinkedList<>();
     private final Set<String> requestedExpansions;
+    // Case-insensitive lookup mirror of requestedExpansions, kept separate so
+    // getRequestedExpansions() still returns the paths in their original casing.
+    private final Set<String> normalizedExpansions;
 
     public ExpansionPathTracker(Set<String> requestedExpansions) {
         if (requestedExpansions == null) {
             throw new IllegalArgumentException("Requested expansions cannot be null");
         }
         this.requestedExpansions = Set.copyOf(requestedExpansions);
+        this.normalizedExpansions = requestedExpansions.stream()
+                .map(path -> path.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     /// Pushes an entity onto the current processing path (top of stack).
@@ -85,7 +92,9 @@ public class ExpansionPathTracker {
 
     /// Checks if a specific association should be expanded based on the current path.
     /// This method checks both dot notation expansions (e.g., `Inventory.Product.Category`)
-    /// and entity-based expansions (e.g., `Category`) for backward compatibility.
+    /// and entity-based expansions (e.g., `Category`) for backward compatibility. Matching is
+    /// case-insensitive, consistent with the `$filter` association-name fallback in
+    /// `ConditionFactory#resolveAssociationOwningField`.
     ///
     /// @param association the association metadata to check for expansion
     /// @return true if the association should be expanded, false otherwise
@@ -94,7 +103,7 @@ public class ExpansionPathTracker {
             throw new IllegalArgumentException("Association cannot be null");
         }
         String fullPath = getCurrentDotPath(association);
-        return requestedExpansions.contains(fullPath);
+        return normalizedExpansions.contains(fullPath.toLowerCase(Locale.ROOT));
     }
 
     /// Gets the current path depth.

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/parser/ConditionFactory.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/parser/ConditionFactory.java
@@ -2,6 +2,7 @@ package com.github.silent.samurai.speedy.parser;
 
 import com.github.silent.samurai.speedy.enums.ConditionOperator;
 import com.github.silent.samurai.speedy.exceptions.BadRequestException;
+import com.github.silent.samurai.speedy.exceptions.NotFoundException;
 import com.github.silent.samurai.speedy.exceptions.SpeedyHttpException;
 import com.github.silent.samurai.speedy.interfaces.metadata.EntityMetadata;
 import com.github.silent.samurai.speedy.interfaces.metadata.FieldMetadata;
@@ -13,6 +14,9 @@ import com.github.silent.samurai.speedy.models.conditions.NormalField;
 import com.github.silent.samurai.speedy.models.conditions.AssociatedField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ConditionFactory {
 
@@ -58,7 +62,7 @@ public class ConditionFactory {
     }
 
     public QueryField createAssociatedField(String field, String associatedField) throws SpeedyHttpException {
-        FieldMetadata fieldMetadata = this.entityMetadata.getField(field);
+        FieldMetadata fieldMetadata = resolveAssociationOwningField(field);
         if (!fieldMetadata.isAssociation()) {
             throw new BadRequestException("field is not an association: " + fieldMetadata.getOutputPropertyName());
         }
@@ -72,6 +76,36 @@ public class ConditionFactory {
         EntityMetadata associationMetadata = fieldMetadata.getAssociationMetadata();
         FieldMetadata associatedFieldMetadata = associationMetadata.getField(associatedField);
         return new AssociatedField(fieldMetadata, associatedFieldMetadata);
+    }
+
+    /**
+     * Resolves the owning side of an association path segment (the {@code product} in
+     * {@code product.id}). Tries the field's own output name first; if that misses, falls back
+     * to matching by the associated entity's name, case-insensitively — e.g. {@code product.id}
+     * or {@code Product.id} both resolve to whichever field associates with the {@code Product}
+     * entity, the same convention {@code $expand} already uses ({@code ExpansionPathTracker}
+     * matches by entity name, not the owning field's output name — also case-insensitively).
+     * Ambiguous matches (two fields to the same target entity) are rejected rather than guessed at.
+     */
+    private FieldMetadata resolveAssociationOwningField(String field) throws SpeedyHttpException {
+        if (entityMetadata.has(field)) {
+            return entityMetadata.getField(field);
+        }
+        List<FieldMetadata> byAssociationName = entityMetadata.getAssociatedFields().stream()
+                .filter(f -> f.getAssociationMetadata().getName().equalsIgnoreCase(field))
+                .collect(Collectors.toList());
+        if (byAssociationName.size() == 1) {
+            return byAssociationName.get(0);
+        }
+        if (byAssociationName.size() > 1) {
+            String candidates = byAssociationName.stream()
+                    .map(FieldMetadata::getOutputPropertyName)
+                    .collect(Collectors.joining(", "));
+            throw new BadRequestException(String.format(
+                    "'%s' matches multiple associations on entity %s (%s) — reference one of these field names directly",
+                    field, entityMetadata.getName(), candidates));
+        }
+        throw new NotFoundException(String.format("Field '%s' not found in entity %s", field, entityMetadata.getName()));
     }
 
     /**

--- a/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/AliasedCategoryRefEntity.java
+++ b/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/AliasedCategoryRefEntity.java
@@ -1,0 +1,29 @@
+package com.github.silent.samurai.speedy.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+// A native @ManyToOne field ("cat") whose Java name deliberately differs from its target
+// entity's name ("Category") -- proves the ConditionFactory association-name fallback (see
+// AssociationNameFallbackTest) benefits real JPA relationships identically to @SpeedyAssociation,
+// since the fallback operates purely on FieldMetadata/EntityMetadata and has no notion of how
+// the association was declared.
+@Getter
+@Setter
+@Table(name = "ALIASED_CATEGORY_REF_ENTITY")
+@Entity
+public class AliasedCategoryRefEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    protected UUID id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "cat_id", nullable = false)
+    private Category cat;
+
+}

--- a/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/SuffixedFkEntity.java
+++ b/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/SuffixedFkEntity.java
@@ -1,0 +1,31 @@
+package com.github.silent.samurai.speedy.entity;
+
+import com.github.silent.samurai.speedy.annotations.SpeedyAssociation;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+// Reproduces a downstream-reported NotFoundException: a @SpeedyAssociation field named with the
+// conventional DB/Kotlin "Id" suffix (e.g. "productId") is exposed under that literal Java member
+// name, NOT the suffix-stripped form ("product") that a caller might assume mirrors @ManyToOne
+// naming (see docs/speedy-jpa.md's `target` example, which carries no suffix at all). Querying
+// "product.id" against this entity fails with "Field 'product' not found in entity SuffixedFkEntity";
+// the correct path is "productId.id".
+@Getter
+@Setter
+@Table(name = "SUFFIXED_FK_ENTITY")
+@Entity
+public class SuffixedFkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    protected UUID id;
+
+    @Column(name = "product_id", nullable = true)
+    @SpeedyAssociation(entity = "PkUuidTest")
+    private UUID productId;
+
+}

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/AssociationNameFallbackTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/AssociationNameFallbackTest.java
@@ -1,0 +1,145 @@
+package com.github.silent.samurai.speedy.entity;
+
+import com.github.silent.samurai.speedy.TestApplication;
+import com.github.silent.samurai.speedy.client.test.SpeedyTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.condition;
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.eq;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+// ConditionFactory#resolveAssociationOwningField lets an association path (e.g. "X.id") be
+// addressed by the *associated entity's name*, not just the owning field's own output name --
+// the same convention $expand already uses (ExpansionPathTracker matches by entity name). This
+// is a fallback: the field's own name is always tried first, and it's still required when two
+// fields on the same entity target the same associated entity (there's no single field to pick).
+// Matching is case-insensitive on both sides (ConditionFactory and ExpansionPathTracker), so
+// this stays consistent with $expand rather than diverging from it.
+//
+// Reuses ScalarFkEntity's fixtures (see ScalarFkAssociationTest) for the @SpeedyAssociation
+// cases, since it already has both a uniquely-targeted association (catRef -> Category) and an
+// ambiguous pair (ref & refByName both -> PkUuidTest). AliasedCategoryRefEntity covers the same
+// fallback for a genuine JPA-native @ManyToOne whose field name isn't the target entity's name.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AssociationNameFallbackTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    private SpeedyTest speedyClient;
+
+    @BeforeEach
+    void setUp() {
+        speedyClient = SpeedyTest.mockMvc(mvc);
+    }
+
+    private String createCategory() {
+        return speedyClient.create("Category")
+                .field("name", "cat-" + UUID.randomUUID())
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+    }
+
+    @Test
+    void query_speedyAssociation_filterByUniqueAssociatedEntityName_navigatesThroughAssociation() {
+        // Only ScalarFkEntity.catRef targets Category, so "Category.id" is unambiguous.
+        String categoryId = createCategory();
+
+        speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("catRef.id", categoryId)
+                .execute()
+                .expectOk();
+
+        speedyClient.query("ScalarFkEntity")
+                .where(condition("Category.id", eq(categoryId)))
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].id");
+    }
+
+    @Test
+    void query_speedyAssociation_filterByAmbiguousAssociatedEntityName_isRejected() {
+        // Both ScalarFkEntity.ref and .refByName target PkUuidTest, so "PkUuidTest.id" can't
+        // pick a single field -- it must be rejected rather than silently picking one.
+        speedyClient.query("ScalarFkEntity")
+                .where(condition("PkUuidTest.id", eq(UUID.randomUUID().toString())))
+                .execute()
+                .expectBadRequest()
+                .expectJsonPath("$.message", allOf(
+                        containsString("PkUuidTest"),
+                        containsString("ref"),
+                        containsString("refByName")));
+    }
+
+    @Test
+    void query_speedyAssociation_filterByOwnFieldName_stillWorksAlongsideAmbiguousEntityName() {
+        // Even though "PkUuidTest.id" alone is ambiguous on ScalarFkEntity, the owning field's
+        // own name always resolves directly -- the fallback never shadows the primary path.
+        String targetId = speedyClient.create("PkUuidTest")
+                .field("name", "target-" + UUID.randomUUID())
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("ref.id", targetId)
+                .execute()
+                .expectOk();
+
+        speedyClient.query("ScalarFkEntity")
+                .where(condition("ref.id", eq(targetId)))
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].id");
+    }
+
+    @Test
+    void query_speedyAssociation_filterByAssociatedEntityName_isCaseInsensitive() {
+        // Speedy entity names are PascalCase by JPA/Java convention ("Category"), but a caller
+        // may reasonably type a lowercase field-style name ("category") -- both must resolve to
+        // the same field, matching ExpansionPathTracker's case-insensitive $expand behavior.
+        String categoryId = createCategory();
+
+        speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("catRef.id", categoryId)
+                .execute()
+                .expectOk();
+
+        speedyClient.query("ScalarFkEntity")
+                .where(condition("category.id", eq(categoryId)))
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].id");
+    }
+
+    @Test
+    void query_nativeManyToOne_filterByAssociatedEntityName_navigatesThroughAssociation() {
+        // AliasedCategoryRefEntity.cat is a plain @ManyToOne/@JoinColumn -- no @SpeedyAssociation
+        // involved -- proving the fallback applies to every association kind, not just manual ones.
+        String categoryId = createCategory();
+
+        speedyClient.create("AliasedCategoryRefEntity")
+                .field("cat.id", categoryId)
+                .execute()
+                .expectOk();
+
+        speedyClient.query("AliasedCategoryRefEntity")
+                .where(condition("Category.id", eq(categoryId)))
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].id");
+    }
+}

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/ScalarFkAssociationTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/ScalarFkAssociationTest.java
@@ -242,4 +242,79 @@ class ScalarFkAssociationTest {
                 .expectOk()
                 .expectJsonPathExists("$.payload[0].id");
     }
+
+    @Test
+    void update_reassigningAssociationField_changesReference() {
+        String firstTargetId = createTarget();
+        String secondTargetId = createTarget();
+
+        String sourceId = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("ref.id", firstTargetId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.update("ScalarFkEntity")
+                .key("id", sourceId)
+                .field("ref.id", secondTargetId)
+                .execute()
+                .expectOk();
+
+        speedyClient.get("ScalarFkEntity")
+                .key("id", sourceId)
+                .execute()
+                .expectOk()
+                .expectJsonPath("$.payload[0].ref.id", secondTargetId);
+    }
+
+    @Test
+    void update_withNumericPkTarget_reassignsReference() {
+        // Confirms the update path also drives the write conversion through the *target* key
+        // field's type (Long/IDENTITY here), same as create.
+        long firstTargetId = createIdentityTarget();
+        long secondTargetId = createIdentityTarget();
+
+        String sourceId = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("numRef.id", firstTargetId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.update("ScalarFkEntity")
+                .key("id", sourceId)
+                .field("numRef.id", secondTargetId)
+                .execute()
+                .expectOk();
+
+        Object actual = speedyClient.get("ScalarFkEntity")
+                .key("id", sourceId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].numRef.id", Object.class);
+
+        assertThat(Long.parseLong(String.valueOf(actual)), is(secondTargetId));
+    }
+
+    @Test
+    void update_withBareScalarPayload_isRejected() {
+        // Same StructureToSpeedy-level rejection as create_withBareScalarPayload_isRejected —
+        // association fields must be sent as a nested object on update too.
+        String targetId = createTarget();
+
+        String sourceId = speedyClient.create("ScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("ref.id", targetId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.update("ScalarFkEntity")
+                .key("id", sourceId)
+                .field("ref", UUID.randomUUID().toString())
+                .execute()
+                .expectBadRequest()
+                .expectJsonPath("$.message", containsString("must be an object"));
+    }
 }

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/SuffixedAssociationFieldNameTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/SuffixedAssociationFieldNameTest.java
@@ -1,0 +1,70 @@
+package com.github.silent.samurai.speedy.entity;
+
+import com.github.silent.samurai.speedy.TestApplication;
+import com.github.silent.samurai.speedy.client.test.SpeedyTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.condition;
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.eq;
+import static org.hamcrest.Matchers.containsString;
+
+// Repro for a NotFoundException reported against a downstream consumer's @SpeedyAssociation field
+// named with an "Id" suffix (its Kotlin entity: `productId: UUID` on `Inventory`, targeting
+// `Product`). The field is exposed under its literal member name ("productId"), not a
+// suffix-stripped alias ("product") — there is no such stripping anywhere in the metamodel
+// processor (see JpaMetaModelProcessorV2#findOutputName, which just returns member.getName()
+// absent a @JsonProperty override). So filtering via "product.id" 404s, while "productId.id"
+// works exactly like any other association field path. See SuffixedFkEntity for the reproducing
+// entity.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SuffixedAssociationFieldNameTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    private SpeedyTest speedyClient;
+
+    @BeforeEach
+    void setUp() {
+        speedyClient = SpeedyTest.mockMvc(mvc);
+    }
+
+    @Test
+    void query_bySuffixStrippedFieldName_isNotFound() {
+        // This is the exact shape of the reported failure: querying "product.id" against a field
+        // that is actually named "productId" in the entity.
+        speedyClient.query("SuffixedFkEntity")
+                .where(condition("product.id", eq(UUID.randomUUID().toString())))
+                .execute()
+                .expectNotFound()
+                .expectJsonPath("$.message", containsString("Field 'product' not found in entity SuffixedFkEntity"));
+    }
+
+    @Test
+    void query_byActualFieldName_navigatesThroughAssociation() {
+        String targetId = speedyClient.create("PkUuidTest")
+                .field("name", "target-" + UUID.randomUUID())
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.create("SuffixedFkEntity")
+                .field("productId.id", targetId)
+                .execute()
+                .expectOk();
+
+        speedyClient.query("SuffixedFkEntity")
+                .where(condition("productId.id", eq(targetId)))
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].id");
+    }
+}


### PR DESCRIPTION
## Summary
- `ConditionFactory` now resolves an association path segment (e.g. `Product` in `Product.id`) by the *associated entity's name* as a fallback when it doesn't match a field's own output name — the same convention `$expand` already uses via `ExpansionPathTracker`. Ambiguous matches (two fields on the same entity targeting the same associated entity) are rejected with a message naming the candidate fields instead of guessing.
- `ExpansionPathTracker` matching is now case-insensitive too, so `$expand` and this new `$filter` fallback stay consistent with each other rather than diverging.
- Adds `$update` test coverage for `@SpeedyAssociation` fields (reassigning a reference, cross-PK-type reassignment, bare-scalar rejection).
- Adds two fixtures used by the new tests: `SuffixedFkEntity` (an "Id"-suffixed field name, reproducing a downstream `NotFoundException` report) and `AliasedCategoryRefEntity` (a native `@ManyToOne` field whose name differs from its target entity's name).

## Test plan
- [x] `mvn -pl speedy-commons test` — `ExpansionPathTrackerTest` (24 nested tests) all green
- [x] `mvn -pl speedy-test-app test -Dtest=AssociationNameFallbackTest,SuffixedAssociationFieldNameTest,ScalarFkAssociationTest,SpeedyV2ExpandTest` — all green
- [x] `mvn -pl speedy-test-app test` (full module, 689 tests) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)