### PR TITLE
Add @SpeedyAssociation name() and fix composite-key ordering

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,131 +1,172 @@
 version: '3'
 
 vars:
-  TEST_APP_DIR: speedy-test-app
-  LOAD_TEST_DIR: k6-load-test
-  DB_TEST_DIR: db-tests
+    TEST_APP_DIR: speedy-test-app
+    LOAD_TEST_DIR: k6-load-test
+    DB_TEST_DIR: db-tests
 
 tasks:
-  default:
-    desc: Show available tasks
-    cmds:
-      - task: help
+    default:
+        desc: Show available tasks
+        cmds:
+            -   task: help
 
-  help:
-    desc: Show available tasks
-    cmds:
-      - echo "Speedy-API - Instant REST CRUD APIs for JPA entities"
-      - echo ""
-      - echo "Available tasks:"
-      - echo "  task build              # Build all modules (skip tests)"
-      - echo "  task install            # Install dependencies (skip tests, no clean)"
-      - echo "  task test               # Run all tests (unit + integration)"
-      - echo "  task test:unit          # Unit tests only"
-      - echo "  task test:integration   # Integration tests in speedy-test-app"
-      - echo "  task test:load          # Run k6 load tests"
-      - echo "  task test:db            # Run DB integration tests (Postgres/MySQL)"
-      - echo "  task clean              # Clean all build artifacts"
-      - echo "  task start              # Start speedy-test-app (H2, dev profile)"
-      - echo "  task api-docs:generate  # Generate api-docs.json from springdoc endpoint"
-      - echo "  task docs:serve         # Start docsify documentation server"
+    help:
+        desc: Show available tasks
+        cmds:
+            - echo "Speedy-API - Instant REST CRUD APIs for JPA entities"
+            - echo ""
+            - echo "Available tasks:"
+            - echo "  task build              # Build all modules (skip tests)"
+            - echo "  task install            # Install dependencies (skip tests, no clean)"
+            - echo "  task test               # Run all tests (unit + integration)"
+            - echo "  task test:unit          # Unit tests only"
+            - echo "  task test:integration   # Integration tests in speedy-test-app"
+            - echo "  task test:load          # Run k6 load tests"
+            - echo "  task test:db            # Run DB integration tests (Postgres/MySQL)"
+            - echo "  task clean              # Clean all build artifacts"
+            - echo "  task start              # Start speedy-test-app (H2, dev profile)"
+            - echo "  task api-docs:generate  # Generate api-docs.json from springdoc endpoint"
+            - echo "  task kill-port          # Kill whatever process is listening on a port (default 8080)"
+            - echo "  task docs:serve         # Start docsify documentation server"
 
-  build:
-    desc: Build all modules (skip tests)
-    cmds:
-      - cmd: mvn clean install -DskipTests
+    build:
+        desc: Build all modules (skip tests)
+        cmds:
+            -   cmd: mvn clean install -DskipTests
 
-  release:
-    desc: Install dependencies (skip tests, no clean)
-    cmds:
-      - cmd: mvn install
+    release:
+        desc: Regenerate api-docs.json, rebuild the OpenAPI client against it, and run all tests
+        deps: [ api-docs:generate ]
+        cmds:
+            -   cmd: mvn clean install
 
-  test:
-    desc: Run all tests (unit + integration)
-    cmds:
-      - cmd: mvn clean verify
+    test:
+        desc: Run all tests (unit + integration)
+        cmds:
+            -   cmd: mvn clean verify
 
-  test:unit:
-    desc: Run unit tests only (skip integration tests)
-    cmds:
-      - cmd: mvn clean verify -DskipITs
+    test:unit:
+        desc: Run unit tests only (skip integration tests)
+        cmds:
+            -   cmd: mvn clean verify -DskipITs
 
-  test:integration:
-    desc: Run integration tests in speedy-test-app
-    dir: "{{.TEST_APP_DIR}}"
-    cmds:
-      - cmd: mvn clean verify
+    test:integration:
+        desc: Run integration tests in speedy-test-app
+        dir: "{{.TEST_APP_DIR}}"
+        cmds:
+            -   cmd: mvn clean verify
 
-  test:load:
-    desc: Run k6 load tests
-    dir: "{{.LOAD_TEST_DIR}}"
-    cmds:
-      - cmd: powershell -NoLogo -NoProfile -File run-test.ps1
+    test:load:
+        desc: Run k6 load tests
+        dir: "{{.LOAD_TEST_DIR}}"
+        cmds:
+            -   cmd: powershell -NoLogo -NoProfile -File run-test.ps1
 
-  test:db:
-    desc: Run DB integration tests (starts containers for Postgres/MySQL)
-    dir: "{{.DB_TEST_DIR}}"
-    cmds:
-      - cmd: python run-test.py
+    test:db:
+        desc: Run DB integration tests (starts containers for Postgres/MySQL)
+        dir: "{{.DB_TEST_DIR}}"
+        cmds:
+            -   cmd: python run-test.py
 
-  clean:
-    desc: Clean all build artifacts
-    cmds:
-      - cmd: mvn clean
+    clean:
+        desc: Clean all build artifacts
+        cmds:
+            -   cmd: mvn clean
 
-  api-docs:generate:
-    desc: Generate api-docs.json from springdoc endpoint
-    deps: [build]
-    cmds:
-      - cmd: >-
-          powershell -NoLogo -NoProfile -Command '& {
-            $ErrorActionPreference = "Stop"
-            $apiDocs = "{{.TEST_APP_DIR}}\api-docs.json"
-            $process = Start-Process -NoNewWindow -PassThru -FilePath "mvn.cmd" -ArgumentList "spring-boot:run" -WorkingDirectory "{{.TEST_APP_DIR}}"
-            try {
-              $waitUntil = [DateTime]::Now.AddSeconds(60)
-              $ready = $false
-              while ([DateTime]::Now -lt $waitUntil -and -not $ready) {
-                Start-Sleep -Seconds 2
-                try {
-                  $response = Invoke-WebRequest -Uri "http://localhost:8080/v3/api-docs" -UseBasicParsing -TimeoutSec 5
-                  if ($response.StatusCode -eq 200) { $ready = $true }
-                } catch { }
-              }
-              if (-not $ready) { throw "App did not start within 60s" }
-              $response.Content | Out-File -FilePath $apiDocs -Encoding utf8
-              Write-Host "api-docs.json generated at $apiDocs"
-            } finally {
-              if ($process -and !$process.HasExited) { $process.Kill() }
-            }
-          }'
-        platforms: [windows]
-      - cmd: >-
-          bash -lc '
-            cd {{.TEST_APP_DIR}} &&
-            mvn spring-boot:run &
-            PID=$!
-            for i in $(seq 1 30); do
-              sleep 2
-              if curl -sf http://localhost:8080/v3/api-docs > /dev/null 2>&1; then
-                curl -sf http://localhost:8080/v3/api-docs > api-docs.json
-                echo "api-docs.json generated"
-                kill $PID 2>/dev/null
-                exit 0
-              fi
-            done
-            echo "App did not start within 60s"
-            kill $PID 2>/dev/null
-            exit 1
-          '
-        platforms: [linux, darwin]
+    api-docs:generate:
+        desc: Generate api-docs.json from springdoc endpoint
+        deps: [ build ]
+        vars:
+            API_DOCS_PORT: '{{.API_DOCS_PORT | default "8080"}}'
+            API_DOCS_TIMEOUT_SEC: '{{.API_DOCS_TIMEOUT_SEC | default "60"}}'
+        cmds:
+            # Launch the jar already produced by `build` directly with `java`, instead of `mvn spring-boot:run`.
+            # spring-boot:run forks a child JVM by default, so killing the mvn process it prints leaves the
+            # real app (and port {{.API_DOCS_PORT}}) orphaned. A plain `java -jar` process has no fork, so the
+            # PID/handle we capture here is the one actually holding the port, and is guaranteed to be killed
+            # via try/finally (Windows) or trap (bash) even if the poll below fails or times out.
+            -   cmd: >-
+                    powershell -NoLogo -NoProfile -Command '& {
+                      $ErrorActionPreference = "Stop"
+                      $jar = Get-ChildItem -Path "{{.TEST_APP_DIR}}\target" -Filter "speedy-test-app-*.jar" |
+                             Where-Object { $_.Name -notmatch "sources|javadoc|original" } | Select-Object -First 1
+                      if (-not $jar) { throw "No built jar found in {{.TEST_APP_DIR}}\target - run task build first" }
+                      $apiDocs = "{{.TEST_APP_DIR}}\api-docs.json"
+                      $process = Start-Process -NoNewWindow -PassThru -FilePath "java" -ArgumentList "-jar", $jar.FullName
+                      try {
+                        $waitUntil = [DateTime]::Now.AddSeconds({{.API_DOCS_TIMEOUT_SEC}})
+                        $ready = $false
+                        while ([DateTime]::Now -lt $waitUntil -and -not $ready) {
+                          Start-Sleep -Seconds 2
+                          try {
+                            $response = Invoke-WebRequest -Uri "http://localhost:{{.API_DOCS_PORT}}/v3/api-docs" -UseBasicParsing -TimeoutSec 5
+                            if ($response.StatusCode -eq 200) { $ready = $true }
+                          } catch { }
+                        }
+                        if (-not $ready) { throw "App did not start within {{.API_DOCS_TIMEOUT_SEC}}s" }
+                        $response.Content | Out-File -FilePath $apiDocs -Encoding utf8
+                        Write-Host "api-docs.json generated at $apiDocs"
+                      } finally {
+                        if ($process -and !$process.HasExited) { $process.Kill() }
+                      }
+                    }'
+                platforms: [ windows ]
+            -   cmd: >-
+                    bash -lc '
+                      set -e
+                      JAR=$(ls {{.TEST_APP_DIR}}/target/speedy-test-app-*.jar 2>/dev/null | grep -vE "sources|javadoc|original" | head -n1)
+                      if [ -z "$JAR" ]; then echo "No built jar found in {{.TEST_APP_DIR}}/target - run task build first" >&2; exit 1; fi
+                      apiDocs="{{.TEST_APP_DIR}}/api-docs.json"
+                      java -jar "$JAR" &
+                      PID=$!
+                      trap "kill $PID 2>/dev/null" EXIT
+                      for i in $(seq 1 $(( {{.API_DOCS_TIMEOUT_SEC}} / 2 ))); do
+                        sleep 2
+                        if curl -sf "http://localhost:{{.API_DOCS_PORT}}/v3/api-docs" -o "$apiDocs"; then
+                          echo "api-docs.json generated at $apiDocs"
+                          exit 0
+                        fi
+                      done
+                      echo "App did not start within {{.API_DOCS_TIMEOUT_SEC}}s" >&2
+                      exit 1
+                    '
+                platforms: [ linux, darwin ]
 
-  start:
-    desc: Start speedy-test-app with H2 dev profile
-    dir: "{{.TEST_APP_DIR}}"
-    cmds:
-      - cmd: mvn spring-boot:run
+    kill-port:
+        desc: "Kill whatever process is listening on a port (default 8080). Usage: task kill-port PORT=8080"
+        vars:
+            PORT: '{{.PORT | default "8080"}}'
+        cmds:
+            -   cmd: >-
+                    powershell -NoLogo -NoProfile -Command '& {
+                      $conns = Get-NetTCPConnection -LocalPort {{.PORT}} -State Listen -ErrorAction SilentlyContinue
+                      if (-not $conns) { Write-Host "Nothing listening on port {{.PORT}}"; exit 0 }
+                      $conns | Select-Object -ExpandProperty OwningProcess -Unique | ForEach-Object {
+                        $proc = Get-Process -Id $_ -ErrorAction SilentlyContinue
+                        if ($proc) {
+                          Write-Host "Killing PID $_ ($($proc.ProcessName)) on port {{.PORT}}"
+                          Stop-Process -Id $_ -Force
+                        }
+                      }
+                    }'
+                platforms: [ windows ]
+            -   cmd: >-
+                    bash -lc '
+                      PIDS=$(lsof -ti tcp:{{.PORT}} 2>/dev/null)
+                      if [ -z "$PIDS" ]; then echo "Nothing listening on port {{.PORT}}"; exit 0; fi
+                      echo "Killing PID(s) $PIDS on port {{.PORT}}"
+                      kill -9 $PIDS
+                    '
+                platforms: [ linux, darwin ]
 
-  docs:serve:
-    desc: Start docsify documentation server
-    cmds:
-      - cmd: docsify serve docs
+    start:
+        desc: Start speedy-test-app with H2 dev profile
+        dir: "{{.TEST_APP_DIR}}"
+        cmds:
+            -   cmd: mvn spring-boot:run
+
+    docs:serve:
+        desc: Start docsify documentation server
+        cmds:
+            -   cmd: docsify serve docs

--- a/docs/speedy-jpa.md
+++ b/docs/speedy-jpa.md
@@ -171,6 +171,28 @@ This also means write payloads must use the nested-object shape (`{"target": {"i
 instead of a bare scalar value — a plain `UUID` value is rejected, same as for any other
 association field.
 
+**Renaming the exposed property.** A scalar FK is conventionally named after the column it maps
+(`someFieldId`), but the annotation turns it into an object reference — so left alone it is
+exposed and navigated as `someFieldId.id`, with a `{"someFieldId": {"id": "<uuid>"}}` write
+payload. The `Id` suffix now describes a property that isn't an id. Use `name()` to expose it
+under the name it would have had as a `@ManyToOne`:
+
+```java
+    @Column(name = "some_field_id")
+    @SpeedyAssociation(value = SomeEntity.class, name = "someField")
+    private UUID someFieldId;
+```
+
+The rename applies everywhere the property name surfaces — request/response JSON, the generated
+OpenAPI schema properties, and `$filter` navigation paths (`someField.id`) — while `@Column`
+still drives the DB column name. It is equivalent to putting `@JsonProperty("someField")` on the
+field, just co-located with the annotation that causes the shape change; setting both to
+*different* values fails fast at metamodel build time.
+
+Note that `$expand` is unaffected either way: `$expand` entries are matched by the *associated
+entity's* name, not the owning field's property name (see `ExpansionPathTracker`), the same as
+for every other association kind.
+
 ### Speedy Sensitive
 
 Prevent fields from being used in `$` field references in queries.

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/annotations/SpeedyAssociation.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/annotations/SpeedyAssociation.java
@@ -22,4 +22,19 @@ public @interface SpeedyAssociation {
 
     /// The target Speedy entity name. Mutually exclusive with {@link #value()}.
     String entity() default "";
+
+    /// Renames the property this field is exposed under — request/response JSON, generated OpenAPI
+    /// schema properties, and `$filter` navigation paths. Blank (the default) keeps the field's own
+    /// Java name.
+    ///
+    /// A scalar FK column is conventionally named after the column it maps (`someFieldId`), but
+    /// annotating it makes the field behave like an object reference, so that name reads wrong once
+    /// the association is followed — `someFieldId.id`, and a `{"someFieldId": {"id": ...}}` write
+    /// payload. Set this to the name the field would have had as a `@ManyToOne` (`someField`) and
+    /// paths read `someField.id`, exactly like a native relationship.
+    ///
+    /// Equivalent to putting `@JsonProperty` on the field, but co-located with the annotation that
+    /// causes the shape change. Setting both to *different* values fails fast at metamodel build
+    /// time, since a field can only be exposed under one name.
+    String name() default "";
 }

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityBuilder.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityBuilder.java
@@ -14,7 +14,11 @@ import java.util.stream.Collectors;
 public class EntityBuilder {
     boolean hasCompositeKey;
     Set<ActionType> actionTypes = new HashSet<>(List.of(ActionType.ALL));
-    Map<String, FieldBuilder> fieldMap = new HashMap<>();
+    // LinkedHashMap so field/key iteration order (and thus the order OASGenerator emits
+    // composite-key parameters — the generated Java client's positional method arguments) stays
+    // stable and matches declaration order, rather than an arbitrary hash-bucket order that could
+    // change between JVM runs.
+    Map<String, FieldBuilder> fieldMap = new LinkedHashMap<>();
     private String name;
     private String dbTableName;
     private boolean isSensitive = false;
@@ -121,7 +125,7 @@ public class EntityBuilder {
 
     public EntityMetadataImpl build() throws NotFoundException {
 
-        Map<String, FieldMetadata> fieldMetadataMap = new HashMap<>();
+        Map<String, FieldMetadata> fieldMetadataMap = new LinkedHashMap<>();
         for (Map.Entry<String, FieldBuilder> e : fieldMap.entrySet()) {
             Map.Entry<String, FieldMetadataImpl> entry = Map.entry(e.getKey(), e.getValue().build());
             if (fieldMetadataMap.put(entry.getKey(), entry.getValue()) != null) {

--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityMetadataImpl.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/metadata/EntityMetadataImpl.java
@@ -9,6 +9,8 @@ import com.github.silent.samurai.speedy.interfaces.metadata.KeyFieldMetadata;
 import lombok.Getter;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,7 +41,11 @@ public class EntityMetadataImpl implements EntityMetadata {
         this.hasCompositeKey = hasCompositeKey;
         this.isSensitive = isSensitive;
         this.actionType = actionType == null ? null : Set.copyOf(actionType);
-        this.fieldMap = fieldMap == null ? null : Map.copyOf(fieldMap);
+        // Map.copyOf/Set.copyOf make no iteration-order guarantee; a LinkedHashMap/LinkedHashSet
+        // copy preserves the caller's (declaration) order, which OASGenerator relies on when
+        // emitting composite-key parameters — that order becomes the generated Java client's
+        // positional method arguments.
+        this.fieldMap = fieldMap == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(fieldMap));
     }
 
     @Override
@@ -58,9 +64,9 @@ public class EntityMetadataImpl implements EntityMetadata {
     @Override
     public Set<FieldMetadata> getAllFields() {
         if (allFieldsCache == null) {
-            allFieldsCache = fieldMap.values().stream()
-                    .map(fieldMetadata -> fieldMetadata)
-                    .collect(Collectors.toUnmodifiableSet());
+            LinkedHashSet<FieldMetadata> ordered = fieldMap.values().stream()
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            allFieldsCache = Collections.unmodifiableSet(ordered);
         }
         return allFieldsCache;
     }
@@ -68,9 +74,10 @@ public class EntityMetadataImpl implements EntityMetadata {
     @Override
     public Set<String> getAllFieldNames() {
         if (allFieldNamesCache == null) {
-            allFieldNamesCache = fieldMap.values().stream()
+            LinkedHashSet<String> ordered = fieldMap.values().stream()
                     .map(FieldMetadata::getOutputPropertyName)
-                    .collect(Collectors.toUnmodifiableSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            allFieldNamesCache = Collections.unmodifiableSet(ordered);
         }
         return allFieldNamesCache;
     }
@@ -83,10 +90,11 @@ public class EntityMetadataImpl implements EntityMetadata {
     @Override
     public Set<KeyFieldMetadata> getKeyFields() {
         if (keyFieldsCache == null) {
-            keyFieldsCache = fieldMap.values().stream()
+            LinkedHashSet<KeyFieldMetadata> ordered = fieldMap.values().stream()
                     .filter(KeyFieldMetadata.class::isInstance)
                     .map(KeyFieldMetadata.class::cast)
-                    .collect(Collectors.toUnmodifiableSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            keyFieldsCache = Collections.unmodifiableSet(ordered);
         }
         return keyFieldsCache;
     }
@@ -94,11 +102,12 @@ public class EntityMetadataImpl implements EntityMetadata {
     @Override
     public Set<String> getKeyFieldNames() {
         if (keyFieldNamesCache == null) {
-            keyFieldNamesCache = fieldMap.values().stream()
+            LinkedHashSet<String> ordered = fieldMap.values().stream()
                     .filter(KeyFieldMetadata.class::isInstance)
                     .map(KeyFieldMetadata.class::cast)
                     .map(KeyFieldMetadata::getOutputPropertyName)
-                    .collect(Collectors.toUnmodifiableSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            keyFieldNamesCache = Collections.unmodifiableSet(ordered);
         }
         return keyFieldNamesCache;
     }
@@ -106,9 +115,10 @@ public class EntityMetadataImpl implements EntityMetadata {
     @Override
     public Set<FieldMetadata> getAssociatedFields() {
         if (associatedFieldsCache == null) {
-            associatedFieldsCache = fieldMap.values().stream()
+            LinkedHashSet<FieldMetadata> ordered = fieldMap.values().stream()
                     .filter(FieldMetadata::isAssociation)
-                    .collect(Collectors.toUnmodifiableSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            associatedFieldsCache = Collections.unmodifiableSet(ordered);
         }
         return associatedFieldsCache;
     }

--- a/speedy-mp-jpa/src/main/java/com/github/silent/samurai/speedy/jpa/impl/processors/JpaMetaModelProcessorV2.java
+++ b/speedy-mp-jpa/src/main/java/com/github/silent/samurai/speedy/jpa/impl/processors/JpaMetaModelProcessorV2.java
@@ -470,10 +470,27 @@ public class JpaMetaModelProcessorV2 implements MetaModelProcessor {
         }
     }
 
+    /// Resolves the property name a field is exposed under. Both call sites — {@link #processField}
+    /// and the attribute lookup in {@link #processAssociations} — go through here, so any rename
+    /// stays consistent across the two passes.
     String findOutputName(Field field, Member member) {
         JsonProperty propertyAnnotation = AnnotationUtils.getAnnotation(field, JsonProperty.class);
-        if (propertyAnnotation != null) {
-            return propertyAnnotation.value();
+        String jsonPropertyName = propertyAnnotation != null ? propertyAnnotation.value() : null;
+
+        SpeedyAssociation manualAssociation = AnnotationUtils.getAnnotation(field, SpeedyAssociation.class);
+        if (manualAssociation != null && !manualAssociation.name().isBlank()) {
+            String associationName = manualAssociation.name();
+            if (jsonPropertyName != null && !jsonPropertyName.equals(associationName)) {
+                throw new RuntimeException(String.format(
+                        "@SpeedyAssociation(name = \"%s\") on %s.%s conflicts with @JsonProperty(\"%s\") — " +
+                                "a field can only be exposed under one name",
+                        associationName, member.getDeclaringClass().getSimpleName(), member.getName(), jsonPropertyName));
+            }
+            return associationName;
+        }
+
+        if (jsonPropertyName != null) {
+            return jsonPropertyName;
         }
         return member.getName();
     }

--- a/speedy-mp-jpa/src/main/java/com/github/silent/samurai/speedy/jpa/impl/processors/JpaMetaModelProcessorV2.java
+++ b/speedy-mp-jpa/src/main/java/com/github/silent/samurai/speedy/jpa/impl/processors/JpaMetaModelProcessorV2.java
@@ -109,7 +109,7 @@ public class JpaMetaModelProcessorV2 implements MetaModelProcessor {
         if (speedySensitive != null) {
             entity.sensitive(speedySensitive.value());
         }
-        for (Attribute<?, ?> attribute : entityType.getAttributes()) {
+        for (Attribute<?, ?> attribute : attributesInDeclarationOrder(entityType)) {
             if (isIgnorable(attribute, entityType.getJavaType())) {
                 continue;
             }
@@ -120,6 +120,29 @@ public class JpaMetaModelProcessorV2 implements MetaModelProcessor {
             );
         }
         return entity;
+    }
+
+    /// {@link EntityType#getAttributes()} is backed by a {@code Set} with no ordering guarantee, so
+    /// relying on it directly leaves field order — and, downstream, the order OASGenerator emits
+    /// composite-key parameters (which becomes the generated Java client's *positional* method
+    /// arguments) — to whatever a hash-bucket layout happens to produce. Re-sort by each attribute's
+    /// position in the entity's own declared-field order (walking superclasses first) so it matches
+    /// the order a reader of the entity source would expect, and stays stable across regenerations.
+    private static List<Attribute<?, ?>> attributesInDeclarationOrder(EntityType<?> entityType) {
+        Deque<Class<?>> hierarchy = new ArrayDeque<>();
+        for (Class<?> c = entityType.getJavaType(); c != null && c != Object.class; c = c.getSuperclass()) {
+            hierarchy.addFirst(c);
+        }
+        Map<String, Integer> declarationIndex = new HashMap<>();
+        for (Class<?> klass : hierarchy) {
+            for (Field field : klass.getDeclaredFields()) {
+                declarationIndex.putIfAbsent(field.getName(), declarationIndex.size());
+            }
+        }
+        return entityType.getAttributes().stream()
+                .sorted(Comparator.comparingInt(a ->
+                        declarationIndex.getOrDefault(a.getJavaMember().getName(), Integer.MAX_VALUE)))
+                .collect(Collectors.toList());
     }
 
     boolean isIgnorable(Attribute<?, ?> attribute, Class<?> entityClass) {

--- a/speedy-test-app/api-docs.json
+++ b/speedy-test-app/api-docs.json
@@ -6,7 +6,7 @@
     },
     "servers" : [
         {
-            "url" : "http://localhost",
+            "url" : "http://localhost:8080",
             "description" : "Generated server url"
         }
     ],
@@ -171,7 +171,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateValueTestEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateValueTestEntityRequest"
+                                }
                             }
                         }
                     }
@@ -217,7 +220,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateValueTestEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateValueTestEntityRequest"
+                                }
                             }
                         }
                     }
@@ -286,299 +292,6 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/ValueTestEntityKey"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/ExchangeRate" : {
-            "get" : {
-                "tags" : [
-                    "ExchangeRate"
-                ],
-                "summary" : "Get a(n) ExchangeRate",
-                "operationId" : "GetExchangeRate",
-                "parameters" : [
-                    {
-                        "name" : "id",
-                        "in" : "query",
-                        "description" : "id field value.",
-                        "allowEmptyValue" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    }
-                ],
-                "responses" : {
-                    "200" : {
-                        "description" : "successful fetch.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "FilteredExchangeRateResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ExchangeRate"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/ExchangeRate/$query" : {
-            "post" : {
-                "tags" : [
-                    "ExchangeRate"
-                ],
-                "summary" : "Filter ExchangeRate",
-                "operationId" : "QueryExchangeRate",
-                "requestBody" : {
-                    "description" : "Fields needed for creation",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful fetch.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "FilteredExchangeRateResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ExchangeRate"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/ExchangeRate/$create" : {
-            "post" : {
-                "tags" : [
-                    "ExchangeRate"
-                ],
-                "summary" : "Bulk create ExchangeRate",
-                "operationId" : "BulkCreateExchangeRate",
-                "requestBody" : {
-                    "description" : "Fields needed for creation",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "type" : "array",
-                                "items" : {
-                                    "$ref" : "#/components/schemas/CreateExchangeRateRequest"
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful creation.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "BulkCreateExchangeRateResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ExchangeRateKey"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/ExchangeRate/$update" : {
-            "put" : {
-                "tags" : [
-                    "ExchangeRate"
-                ],
-                "summary" : "Replace a(n) ExchangeRate",
-                "operationId" : "ReplaceExchangeRate",
-                "requestBody" : {
-                    "description" : "Complete representation of the resource",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "$ref" : "#/components/schemas/UpdateExchangeRateRequest"
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful replace.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "UpdateExchangeRateResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ExchangeRate"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch" : {
-                "tags" : [
-                    "ExchangeRate"
-                ],
-                "summary" : "Partially update a(n) ExchangeRate",
-                "operationId" : "UpdateExchangeRate",
-                "requestBody" : {
-                    "description" : "Fields to update (partial)",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "$ref" : "#/components/schemas/UpdateExchangeRateRequest"
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful update.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "UpdateExchangeRateResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ExchangeRate"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/ExchangeRate/$delete" : {
-            "delete" : {
-                "tags" : [
-                    "ExchangeRate"
-                ],
-                "summary" : "Bulk delete ExchangeRate",
-                "operationId" : "BulkDeleteExchangeRate",
-                "requestBody" : {
-                    "description" : "Fields needed for deletion",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "type" : "array",
-                                "items" : {
-                                    "$ref" : "#/components/schemas/ExchangeRateKey"
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful deletion.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "BulkDeleteExchangeRateResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ExchangeRateKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -757,7 +470,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateTaskRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateTaskRequest"
+                                }
                             }
                         }
                     }
@@ -803,7 +519,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateTaskRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateTaskRequest"
+                                }
                             }
                         }
                     }
@@ -872,6 +591,604 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/TaskKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ExchangeRate" : {
+            "get" : {
+                "tags" : [
+                    "ExchangeRate"
+                ],
+                "summary" : "Get a(n) ExchangeRate",
+                "operationId" : "GetExchangeRate",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredExchangeRateResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ExchangeRate"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ExchangeRate/$query" : {
+            "post" : {
+                "tags" : [
+                    "ExchangeRate"
+                ],
+                "summary" : "Filter ExchangeRate",
+                "operationId" : "QueryExchangeRate",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredExchangeRateResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ExchangeRate"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ExchangeRate/$create" : {
+            "post" : {
+                "tags" : [
+                    "ExchangeRate"
+                ],
+                "summary" : "Bulk create ExchangeRate",
+                "operationId" : "BulkCreateExchangeRate",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateExchangeRateRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateExchangeRateResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ExchangeRateKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ExchangeRate/$update" : {
+            "put" : {
+                "tags" : [
+                    "ExchangeRate"
+                ],
+                "summary" : "Replace a(n) ExchangeRate",
+                "operationId" : "ReplaceExchangeRate",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateExchangeRateRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateExchangeRateResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ExchangeRate"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "ExchangeRate"
+                ],
+                "summary" : "Partially update a(n) ExchangeRate",
+                "operationId" : "UpdateExchangeRate",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateExchangeRateRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateExchangeRateResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ExchangeRate"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ExchangeRate/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "ExchangeRate"
+                ],
+                "summary" : "Bulk delete ExchangeRate",
+                "operationId" : "BulkDeleteExchangeRate",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/ExchangeRateKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteExchangeRateResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ExchangeRateKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/SuffixedFkEntity" : {
+            "get" : {
+                "tags" : [
+                    "SuffixedFkEntity"
+                ],
+                "summary" : "Get a(n) SuffixedFkEntity",
+                "operationId" : "GetSuffixedFkEntity",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredSuffixedFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/SuffixedFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/SuffixedFkEntity/$query" : {
+            "post" : {
+                "tags" : [
+                    "SuffixedFkEntity"
+                ],
+                "summary" : "Filter SuffixedFkEntity",
+                "operationId" : "QuerySuffixedFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredSuffixedFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/SuffixedFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/SuffixedFkEntity/$create" : {
+            "post" : {
+                "tags" : [
+                    "SuffixedFkEntity"
+                ],
+                "summary" : "Bulk create SuffixedFkEntity",
+                "operationId" : "BulkCreateSuffixedFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateSuffixedFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateSuffixedFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/SuffixedFkEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/SuffixedFkEntity/$update" : {
+            "put" : {
+                "tags" : [
+                    "SuffixedFkEntity"
+                ],
+                "summary" : "Replace a(n) SuffixedFkEntity",
+                "operationId" : "ReplaceSuffixedFkEntity",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSuffixedFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateSuffixedFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/SuffixedFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "SuffixedFkEntity"
+                ],
+                "summary" : "Partially update a(n) SuffixedFkEntity",
+                "operationId" : "UpdateSuffixedFkEntity",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSuffixedFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateSuffixedFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/SuffixedFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/SuffixedFkEntity/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "SuffixedFkEntity"
+                ],
+                "summary" : "Bulk delete SuffixedFkEntity",
+                "operationId" : "BulkDeleteSuffixedFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/SuffixedFkEntityKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteSuffixedFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/SuffixedFkEntityKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -1050,7 +1367,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCompanyRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCompanyRequest"
+                                }
                             }
                         }
                     }
@@ -1096,7 +1416,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCompanyRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCompanyRequest"
+                                }
                             }
                         }
                     }
@@ -1165,6 +1488,305 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/CompanyKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Category" : {
+            "get" : {
+                "tags" : [
+                    "Category"
+                ],
+                "summary" : "Get a(n) Category",
+                "operationId" : "GetCategory",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredCategoryResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Category"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Category/$query" : {
+            "post" : {
+                "tags" : [
+                    "Category"
+                ],
+                "summary" : "Filter Category",
+                "operationId" : "QueryCategory",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredCategoryResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Category"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Category/$create" : {
+            "post" : {
+                "tags" : [
+                    "Category"
+                ],
+                "summary" : "Bulk create Category",
+                "operationId" : "BulkCreateCategory",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateCategoryRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateCategoryResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/CategoryKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Category/$update" : {
+            "put" : {
+                "tags" : [
+                    "Category"
+                ],
+                "summary" : "Replace a(n) Category",
+                "operationId" : "ReplaceCategory",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCategoryRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateCategoryResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Category"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "Category"
+                ],
+                "summary" : "Partially update a(n) Category",
+                "operationId" : "UpdateCategory",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCategoryRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateCategoryResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Category"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Category/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "Category"
+                ],
+                "summary" : "Bulk delete Category",
+                "operationId" : "BulkDeleteCategory",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CategoryKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteCategoryResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/CategoryKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -1343,7 +1965,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateInvoiceRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateInvoiceRequest"
+                                }
                             }
                         }
                     }
@@ -1389,7 +2014,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateInvoiceRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateInvoiceRequest"
+                                }
                             }
                         }
                     }
@@ -1636,7 +2264,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateUserRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateUserRequest"
+                                }
                             }
                         }
                     }
@@ -1682,7 +2313,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateUserRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateUserRequest"
+                                }
                             }
                         }
                     }
@@ -1751,299 +2385,6 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/UserKey"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/Category" : {
-            "get" : {
-                "tags" : [
-                    "Category"
-                ],
-                "summary" : "Get a(n) Category",
-                "operationId" : "GetCategory",
-                "parameters" : [
-                    {
-                        "name" : "id",
-                        "in" : "query",
-                        "description" : "id field value.",
-                        "allowEmptyValue" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    }
-                ],
-                "responses" : {
-                    "200" : {
-                        "description" : "successful fetch.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "FilteredCategoryResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Category"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/Category/$query" : {
-            "post" : {
-                "tags" : [
-                    "Category"
-                ],
-                "summary" : "Filter Category",
-                "operationId" : "QueryCategory",
-                "requestBody" : {
-                    "description" : "Fields needed for creation",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful fetch.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "FilteredCategoryResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Category"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/Category/$create" : {
-            "post" : {
-                "tags" : [
-                    "Category"
-                ],
-                "summary" : "Bulk create Category",
-                "operationId" : "BulkCreateCategory",
-                "requestBody" : {
-                    "description" : "Fields needed for creation",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "type" : "array",
-                                "items" : {
-                                    "$ref" : "#/components/schemas/CreateCategoryRequest"
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful creation.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "BulkCreateCategoryResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/CategoryKey"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/Category/$update" : {
-            "put" : {
-                "tags" : [
-                    "Category"
-                ],
-                "summary" : "Replace a(n) Category",
-                "operationId" : "ReplaceCategory",
-                "requestBody" : {
-                    "description" : "Complete representation of the resource",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCategoryRequest"
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful replace.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "UpdateCategoryResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Category"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch" : {
-                "tags" : [
-                    "Category"
-                ],
-                "summary" : "Partially update a(n) Category",
-                "operationId" : "UpdateCategory",
-                "requestBody" : {
-                    "description" : "Fields to update (partial)",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCategoryRequest"
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful update.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "UpdateCategoryResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Category"
-                                            }
-                                        },
-                                        "pageSize" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        },
-                                        "pageIndex" : {
-                                            "type" : "integer",
-                                            "format" : "int64"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/speedy/v1/Category/$delete" : {
-            "delete" : {
-                "tags" : [
-                    "Category"
-                ],
-                "summary" : "Bulk delete Category",
-                "operationId" : "BulkDeleteCategory",
-                "requestBody" : {
-                    "description" : "Fields needed for deletion",
-                    "content" : {
-                        "application/json;charset=UTF-8" : {
-                            "schema" : {
-                                "type" : "array",
-                                "items" : {
-                                    "$ref" : "#/components/schemas/CategoryKey"
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses" : {
-                    "200" : {
-                        "description" : "successful deletion.",
-                        "content" : {
-                            "application/json;charset=UTF-8" : {
-                                "schema" : {
-                                    "title" : "BulkDeleteCategoryResponse",
-                                    "type" : "object",
-                                    "properties" : {
-                                        "payload" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/CategoryKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -2222,7 +2563,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCustomerRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCustomerRequest"
+                                }
                             }
                         }
                     }
@@ -2268,7 +2612,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCustomerRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCustomerRequest"
+                                }
                             }
                         }
                     }
@@ -2337,6 +2684,305 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/CustomerKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Article" : {
+            "get" : {
+                "tags" : [
+                    "Article"
+                ],
+                "summary" : "Get a(n) Article",
+                "operationId" : "GetArticle",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredArticleResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Article"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Article/$query" : {
+            "post" : {
+                "tags" : [
+                    "Article"
+                ],
+                "summary" : "Filter Article",
+                "operationId" : "QueryArticle",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredArticleResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Article"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Article/$create" : {
+            "post" : {
+                "tags" : [
+                    "Article"
+                ],
+                "summary" : "Bulk create Article",
+                "operationId" : "BulkCreateArticle",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateArticleRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateArticleResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ArticleKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Article/$update" : {
+            "put" : {
+                "tags" : [
+                    "Article"
+                ],
+                "summary" : "Replace a(n) Article",
+                "operationId" : "ReplaceArticle",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateArticleRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateArticleResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Article"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "Article"
+                ],
+                "summary" : "Partially update a(n) Article",
+                "operationId" : "UpdateArticle",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateArticleRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateArticleResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Article"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Article/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "Article"
+                ],
+                "summary" : "Bulk delete Article",
+                "operationId" : "BulkDeleteArticle",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/ArticleKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteArticleResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ArticleKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -2515,7 +3161,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCustomTypeEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCustomTypeEntityRequest"
+                                }
                             }
                         }
                     }
@@ -2561,7 +3210,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCustomTypeEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCustomTypeEntityRequest"
+                                }
                             }
                         }
                     }
@@ -2808,7 +3460,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdatePkUuidTestRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdatePkUuidTestRequest"
+                                }
                             }
                         }
                     }
@@ -2854,7 +3509,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdatePkUuidTestRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdatePkUuidTestRequest"
+                                }
                             }
                         }
                     }
@@ -2923,6 +3581,305 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/PkUuidTestKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ScalarFkEntity" : {
+            "get" : {
+                "tags" : [
+                    "ScalarFkEntity"
+                ],
+                "summary" : "Get a(n) ScalarFkEntity",
+                "operationId" : "GetScalarFkEntity",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ScalarFkEntity/$query" : {
+            "post" : {
+                "tags" : [
+                    "ScalarFkEntity"
+                ],
+                "summary" : "Filter ScalarFkEntity",
+                "operationId" : "QueryScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ScalarFkEntity/$create" : {
+            "post" : {
+                "tags" : [
+                    "ScalarFkEntity"
+                ],
+                "summary" : "Bulk create ScalarFkEntity",
+                "operationId" : "BulkCreateScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateScalarFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ScalarFkEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ScalarFkEntity/$update" : {
+            "put" : {
+                "tags" : [
+                    "ScalarFkEntity"
+                ],
+                "summary" : "Replace a(n) ScalarFkEntity",
+                "operationId" : "ReplaceScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateScalarFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "ScalarFkEntity"
+                ],
+                "summary" : "Partially update a(n) ScalarFkEntity",
+                "operationId" : "UpdateScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateScalarFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/ScalarFkEntity/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "ScalarFkEntity"
+                ],
+                "summary" : "Bulk delete ScalarFkEntity",
+                "operationId" : "BulkDeleteScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/ScalarFkEntityKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/ScalarFkEntityKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -3101,7 +4058,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateProductRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateProductRequest"
+                                }
                             }
                         }
                     }
@@ -3147,7 +4107,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateProductRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateProductRequest"
+                                }
                             }
                         }
                     }
@@ -3394,7 +4357,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateEntityWithIgnoredFieldRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateEntityWithIgnoredFieldRequest"
+                                }
                             }
                         }
                     }
@@ -3440,7 +4406,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateEntityWithIgnoredFieldRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateEntityWithIgnoredFieldRequest"
+                                }
                             }
                         }
                     }
@@ -3688,7 +4657,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateAutoGenAutoEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAutoGenAutoEntityRequest"
+                                }
                             }
                         }
                     }
@@ -3734,7 +4706,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateAutoGenAutoEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAutoGenAutoEntityRequest"
+                                }
                             }
                         }
                     }
@@ -3803,6 +4778,305 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/AutoGenAutoEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Document" : {
+            "get" : {
+                "tags" : [
+                    "Document"
+                ],
+                "summary" : "Get a(n) Document",
+                "operationId" : "GetDocument",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredDocumentResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Document"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Document/$query" : {
+            "post" : {
+                "tags" : [
+                    "Document"
+                ],
+                "summary" : "Filter Document",
+                "operationId" : "QueryDocument",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredDocumentResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Document"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Document/$create" : {
+            "post" : {
+                "tags" : [
+                    "Document"
+                ],
+                "summary" : "Bulk create Document",
+                "operationId" : "BulkCreateDocument",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateDocumentRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateDocumentResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/DocumentKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Document/$update" : {
+            "put" : {
+                "tags" : [
+                    "Document"
+                ],
+                "summary" : "Replace a(n) Document",
+                "operationId" : "ReplaceDocument",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateDocumentRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateDocumentResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Document"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "Document"
+                ],
+                "summary" : "Partially update a(n) Document",
+                "operationId" : "UpdateDocument",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateDocumentRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateDocumentResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Document"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Document/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "Document"
+                ],
+                "summary" : "Bulk delete Document",
+                "operationId" : "BulkDeleteDocument",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/DocumentKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteDocumentResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/DocumentKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -3981,7 +5255,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateJsonPropertyEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateJsonPropertyEntityRequest"
+                                }
                             }
                         }
                     }
@@ -4027,7 +5304,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateJsonPropertyEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateJsonPropertyEntityRequest"
+                                }
                             }
                         }
                     }
@@ -4274,7 +5554,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateBulkDisabledEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateBulkDisabledEntityRequest"
+                                }
                             }
                         }
                     }
@@ -4320,7 +5603,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateBulkDisabledEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateBulkDisabledEntityRequest"
+                                }
                             }
                         }
                     }
@@ -4665,7 +5951,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateAutoGenIdentityEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAutoGenIdentityEntityRequest"
+                                }
                             }
                         }
                     }
@@ -4711,7 +6000,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateAutoGenIdentityEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAutoGenIdentityEntityRequest"
+                                }
                             }
                         }
                     }
@@ -4780,6 +6072,305 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/AutoGenIdentityEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AliasedCategoryRefEntity" : {
+            "get" : {
+                "tags" : [
+                    "AliasedCategoryRefEntity"
+                ],
+                "summary" : "Get a(n) AliasedCategoryRefEntity",
+                "operationId" : "GetAliasedCategoryRefEntity",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredAliasedCategoryRefEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AliasedCategoryRefEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AliasedCategoryRefEntity/$query" : {
+            "post" : {
+                "tags" : [
+                    "AliasedCategoryRefEntity"
+                ],
+                "summary" : "Filter AliasedCategoryRefEntity",
+                "operationId" : "QueryAliasedCategoryRefEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredAliasedCategoryRefEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AliasedCategoryRefEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AliasedCategoryRefEntity/$create" : {
+            "post" : {
+                "tags" : [
+                    "AliasedCategoryRefEntity"
+                ],
+                "summary" : "Bulk create AliasedCategoryRefEntity",
+                "operationId" : "BulkCreateAliasedCategoryRefEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateAliasedCategoryRefEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateAliasedCategoryRefEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AliasedCategoryRefEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AliasedCategoryRefEntity/$update" : {
+            "put" : {
+                "tags" : [
+                    "AliasedCategoryRefEntity"
+                ],
+                "summary" : "Replace a(n) AliasedCategoryRefEntity",
+                "operationId" : "ReplaceAliasedCategoryRefEntity",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAliasedCategoryRefEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateAliasedCategoryRefEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AliasedCategoryRefEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "AliasedCategoryRefEntity"
+                ],
+                "summary" : "Partially update a(n) AliasedCategoryRefEntity",
+                "operationId" : "UpdateAliasedCategoryRefEntity",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAliasedCategoryRefEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateAliasedCategoryRefEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AliasedCategoryRefEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AliasedCategoryRefEntity/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "AliasedCategoryRefEntity"
+                ],
+                "summary" : "Bulk delete AliasedCategoryRefEntity",
+                "operationId" : "BulkDeleteAliasedCategoryRefEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/AliasedCategoryRefEntityKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteAliasedCategoryRefEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AliasedCategoryRefEntityKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -4958,7 +6549,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensitiveTestEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensitiveTestEntityRequest"
+                                }
                             }
                         }
                     }
@@ -5004,7 +6598,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensitiveTestEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensitiveTestEntityRequest"
+                                }
                             }
                         }
                     }
@@ -5073,6 +6670,305 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/SensitiveTestEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/BulkCreateOnlyEntity" : {
+            "get" : {
+                "tags" : [
+                    "BulkCreateOnlyEntity"
+                ],
+                "summary" : "Get a(n) BulkCreateOnlyEntity",
+                "operationId" : "GetBulkCreateOnlyEntity",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredBulkCreateOnlyEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/BulkCreateOnlyEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/BulkCreateOnlyEntity/$query" : {
+            "post" : {
+                "tags" : [
+                    "BulkCreateOnlyEntity"
+                ],
+                "summary" : "Filter BulkCreateOnlyEntity",
+                "operationId" : "QueryBulkCreateOnlyEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredBulkCreateOnlyEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/BulkCreateOnlyEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/BulkCreateOnlyEntity/$create" : {
+            "post" : {
+                "tags" : [
+                    "BulkCreateOnlyEntity"
+                ],
+                "summary" : "Bulk create BulkCreateOnlyEntity",
+                "operationId" : "BulkCreateBulkCreateOnlyEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateBulkCreateOnlyEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateBulkCreateOnlyEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/BulkCreateOnlyEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/BulkCreateOnlyEntity/$update" : {
+            "put" : {
+                "tags" : [
+                    "BulkCreateOnlyEntity"
+                ],
+                "summary" : "Replace a(n) BulkCreateOnlyEntity",
+                "operationId" : "ReplaceBulkCreateOnlyEntity",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateBulkCreateOnlyEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateBulkCreateOnlyEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/BulkCreateOnlyEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "BulkCreateOnlyEntity"
+                ],
+                "summary" : "Partially update a(n) BulkCreateOnlyEntity",
+                "operationId" : "UpdateBulkCreateOnlyEntity",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateBulkCreateOnlyEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateBulkCreateOnlyEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/BulkCreateOnlyEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/BulkCreateOnlyEntity/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "BulkCreateOnlyEntity"
+                ],
+                "summary" : "Bulk delete BulkCreateOnlyEntity",
+                "operationId" : "BulkDeleteBulkCreateOnlyEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/BulkCreateOnlyEntityKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteBulkCreateOnlyEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/BulkCreateOnlyEntityKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -5251,7 +7147,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCurrencyRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCurrencyRequest"
+                                }
                             }
                         }
                     }
@@ -5297,7 +7196,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateCurrencyRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateCurrencyRequest"
+                                }
                             }
                         }
                     }
@@ -5544,7 +7446,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensitiveClassEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensitiveClassEntityRequest"
+                                }
                             }
                         }
                     }
@@ -5590,7 +7495,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensitiveClassEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensitiveClassEntityRequest"
+                                }
                             }
                         }
                     }
@@ -5837,7 +7745,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSupplierRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSupplierRequest"
+                                }
                             }
                         }
                     }
@@ -5883,7 +7794,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSupplierRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSupplierRequest"
+                                }
                             }
                         }
                     }
@@ -5952,6 +7866,305 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/SupplierKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/RenamedScalarFkEntity" : {
+            "get" : {
+                "tags" : [
+                    "RenamedScalarFkEntity"
+                ],
+                "summary" : "Get a(n) RenamedScalarFkEntity",
+                "operationId" : "GetRenamedScalarFkEntity",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredRenamedScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/RenamedScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/RenamedScalarFkEntity/$query" : {
+            "post" : {
+                "tags" : [
+                    "RenamedScalarFkEntity"
+                ],
+                "summary" : "Filter RenamedScalarFkEntity",
+                "operationId" : "QueryRenamedScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredRenamedScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/RenamedScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/RenamedScalarFkEntity/$create" : {
+            "post" : {
+                "tags" : [
+                    "RenamedScalarFkEntity"
+                ],
+                "summary" : "Bulk create RenamedScalarFkEntity",
+                "operationId" : "BulkCreateRenamedScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateRenamedScalarFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateRenamedScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/RenamedScalarFkEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/RenamedScalarFkEntity/$update" : {
+            "put" : {
+                "tags" : [
+                    "RenamedScalarFkEntity"
+                ],
+                "summary" : "Replace a(n) RenamedScalarFkEntity",
+                "operationId" : "ReplaceRenamedScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateRenamedScalarFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateRenamedScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/RenamedScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "RenamedScalarFkEntity"
+                ],
+                "summary" : "Partially update a(n) RenamedScalarFkEntity",
+                "operationId" : "UpdateRenamedScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateRenamedScalarFkEntityRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateRenamedScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/RenamedScalarFkEntity"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/RenamedScalarFkEntity/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "RenamedScalarFkEntity"
+                ],
+                "summary" : "Bulk delete RenamedScalarFkEntity",
+                "operationId" : "BulkDeleteRenamedScalarFkEntity",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/RenamedScalarFkEntityKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteRenamedScalarFkEntityResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/RenamedScalarFkEntityKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -6139,7 +8352,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateOrderRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateOrderRequest"
+                                }
                             }
                         }
                     }
@@ -6185,7 +8401,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateOrderRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateOrderRequest"
+                                }
                             }
                         }
                     }
@@ -6432,7 +8651,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateProcurementRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateProcurementRequest"
+                                }
                             }
                         }
                     }
@@ -6478,7 +8700,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateProcurementRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateProcurementRequest"
+                                }
                             }
                         }
                     }
@@ -6725,7 +8950,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensitiveFkEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensitiveFkEntityRequest"
+                                }
                             }
                         }
                     }
@@ -6771,7 +8999,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensitiveFkEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensitiveFkEntityRequest"
+                                }
                             }
                         }
                     }
@@ -7018,7 +9249,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateTypeOverrideEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateTypeOverrideEntityRequest"
+                                }
                             }
                         }
                     }
@@ -7064,7 +9298,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateTypeOverrideEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateTypeOverrideEntityRequest"
+                                }
                             }
                         }
                     }
@@ -7160,18 +9397,18 @@
                 "operationId" : "GetPriceHistory",
                 "parameters" : [
                     {
-                        "name" : "effectiveAt",
+                        "name" : "productId",
                         "in" : "query",
-                        "description" : "effectiveAt field value.",
+                        "description" : "productId field value.",
                         "allowEmptyValue" : false,
                         "schema" : {
                             "type" : "string"
                         }
                     },
                     {
-                        "name" : "productId",
+                        "name" : "effectiveAt",
                         "in" : "query",
-                        "description" : "productId field value.",
+                        "description" : "effectiveAt field value.",
                         "allowEmptyValue" : false,
                         "schema" : {
                             "type" : "string"
@@ -7320,7 +9557,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdatePriceHistoryRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdatePriceHistoryRequest"
+                                }
                             }
                         }
                     }
@@ -7366,7 +9606,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdatePriceHistoryRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdatePriceHistoryRequest"
+                                }
                             }
                         }
                     }
@@ -7613,7 +9856,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateManyToManyEntityARequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateManyToManyEntityARequest"
+                                }
                             }
                         }
                     }
@@ -7659,7 +9905,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateManyToManyEntityARequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateManyToManyEntityARequest"
+                                }
                             }
                         }
                     }
@@ -7906,7 +10155,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateManyToManyEntityBRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateManyToManyEntityBRequest"
+                                }
                             }
                         }
                     }
@@ -7952,7 +10204,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateManyToManyEntityBRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateManyToManyEntityBRequest"
+                                }
                             }
                         }
                     }
@@ -8039,13 +10294,13 @@
                 }
             }
         },
-        "/speedy/v1/AnnotatedPerson" : {
+        "/speedy/v1/Employee" : {
             "get" : {
                 "tags" : [
-                    "AnnotatedPerson"
+                    "Employee"
                 ],
-                "summary" : "Get a(n) AnnotatedPerson",
-                "operationId" : "GetAnnotatedPerson",
+                "summary" : "Get a(n) Employee",
+                "operationId" : "GetEmployee",
                 "parameters" : [
                     {
                         "name" : "id",
@@ -8063,13 +10318,13 @@
                         "content" : {
                             "application/json;charset=UTF-8" : {
                                 "schema" : {
-                                    "title" : "FilteredAnnotatedPersonResponse",
+                                    "title" : "FilteredEmployeeResponse",
                                     "type" : "object",
                                     "properties" : {
                                         "payload" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                                "$ref" : "#/components/schemas/Employee"
                                             }
                                         },
                                         "pageSize" : {
@@ -8088,13 +10343,13 @@
                 }
             }
         },
-        "/speedy/v1/AnnotatedPerson/$query" : {
+        "/speedy/v1/Employee/$query" : {
             "post" : {
                 "tags" : [
-                    "AnnotatedPerson"
+                    "Employee"
                 ],
-                "summary" : "Filter AnnotatedPerson",
-                "operationId" : "QueryAnnotatedPerson",
+                "summary" : "Filter Employee",
+                "operationId" : "QueryEmployee",
                 "requestBody" : {
                     "description" : "Fields needed for creation",
                     "content" : {
@@ -8111,13 +10366,13 @@
                         "content" : {
                             "application/json;charset=UTF-8" : {
                                 "schema" : {
-                                    "title" : "FilteredAnnotatedPersonResponse",
+                                    "title" : "FilteredEmployeeResponse",
                                     "type" : "object",
                                     "properties" : {
                                         "payload" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                                "$ref" : "#/components/schemas/Employee"
                                             }
                                         },
                                         "pageSize" : {
@@ -8136,13 +10391,13 @@
                 }
             }
         },
-        "/speedy/v1/AnnotatedPerson/$create" : {
+        "/speedy/v1/Employee/$create" : {
             "post" : {
                 "tags" : [
-                    "AnnotatedPerson"
+                    "Employee"
                 ],
-                "summary" : "Bulk create AnnotatedPerson",
-                "operationId" : "BulkCreateAnnotatedPerson",
+                "summary" : "Bulk create Employee",
+                "operationId" : "BulkCreateEmployee",
                 "requestBody" : {
                     "description" : "Fields needed for creation",
                     "content" : {
@@ -8150,7 +10405,7 @@
                             "schema" : {
                                 "type" : "array",
                                 "items" : {
-                                    "$ref" : "#/components/schemas/CreateAnnotatedPersonRequest"
+                                    "$ref" : "#/components/schemas/CreateEmployeeRequest"
                                 }
                             }
                         }
@@ -8162,13 +10417,13 @@
                         "content" : {
                             "application/json;charset=UTF-8" : {
                                 "schema" : {
-                                    "title" : "BulkCreateAnnotatedPersonResponse",
+                                    "title" : "BulkCreateEmployeeResponse",
                                     "type" : "object",
                                     "properties" : {
                                         "payload" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/AnnotatedPersonKey"
+                                                "$ref" : "#/components/schemas/EmployeeKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -8187,19 +10442,22 @@
                 }
             }
         },
-        "/speedy/v1/AnnotatedPerson/$update" : {
+        "/speedy/v1/Employee/$update" : {
             "put" : {
                 "tags" : [
-                    "AnnotatedPerson"
+                    "Employee"
                 ],
-                "summary" : "Replace a(n) AnnotatedPerson",
-                "operationId" : "ReplaceAnnotatedPerson",
+                "summary" : "Replace a(n) Employee",
+                "operationId" : "ReplaceEmployee",
                 "requestBody" : {
                     "description" : "Complete representation of the resource",
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateAnnotatedPersonRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateEmployeeRequest"
+                                }
                             }
                         }
                     }
@@ -8210,13 +10468,13 @@
                         "content" : {
                             "application/json;charset=UTF-8" : {
                                 "schema" : {
-                                    "title" : "UpdateAnnotatedPersonResponse",
+                                    "title" : "UpdateEmployeeResponse",
                                     "type" : "object",
                                     "properties" : {
                                         "payload" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                                "$ref" : "#/components/schemas/Employee"
                                             }
                                         },
                                         "pageSize" : {
@@ -8236,16 +10494,19 @@
             },
             "patch" : {
                 "tags" : [
-                    "AnnotatedPerson"
+                    "Employee"
                 ],
-                "summary" : "Partially update a(n) AnnotatedPerson",
-                "operationId" : "UpdateAnnotatedPerson",
+                "summary" : "Partially update a(n) Employee",
+                "operationId" : "UpdateEmployee",
                 "requestBody" : {
                     "description" : "Fields to update (partial)",
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateAnnotatedPersonRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateEmployeeRequest"
+                                }
                             }
                         }
                     }
@@ -8256,13 +10517,13 @@
                         "content" : {
                             "application/json;charset=UTF-8" : {
                                 "schema" : {
-                                    "title" : "UpdateAnnotatedPersonResponse",
+                                    "title" : "UpdateEmployeeResponse",
                                     "type" : "object",
                                     "properties" : {
                                         "payload" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                                "$ref" : "#/components/schemas/Employee"
                                             }
                                         },
                                         "pageSize" : {
@@ -8281,13 +10542,13 @@
                 }
             }
         },
-        "/speedy/v1/AnnotatedPerson/$delete" : {
+        "/speedy/v1/Employee/$delete" : {
             "delete" : {
                 "tags" : [
-                    "AnnotatedPerson"
+                    "Employee"
                 ],
-                "summary" : "Bulk delete AnnotatedPerson",
-                "operationId" : "BulkDeleteAnnotatedPerson",
+                "summary" : "Bulk delete Employee",
+                "operationId" : "BulkDeleteEmployee",
                 "requestBody" : {
                     "description" : "Fields needed for deletion",
                     "content" : {
@@ -8295,7 +10556,7 @@
                             "schema" : {
                                 "type" : "array",
                                 "items" : {
-                                    "$ref" : "#/components/schemas/AnnotatedPersonKey"
+                                    "$ref" : "#/components/schemas/EmployeeKey"
                                 }
                             }
                         }
@@ -8307,13 +10568,13 @@
                         "content" : {
                             "application/json;charset=UTF-8" : {
                                 "schema" : {
-                                    "title" : "BulkDeleteAnnotatedPersonResponse",
+                                    "title" : "BulkDeleteEmployeeResponse",
                                     "type" : "object",
                                     "properties" : {
                                         "payload" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/AnnotatedPersonKey"
+                                                "$ref" : "#/components/schemas/EmployeeKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -8501,7 +10762,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensorReadingRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensorReadingRequest"
+                                }
                             }
                         }
                     }
@@ -8547,7 +10811,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateSensorReadingRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateSensorReadingRequest"
+                                }
                             }
                         }
                     }
@@ -8643,6 +10910,16 @@
                 "operationId" : "GetTypedCompositeKeyEntity",
                 "parameters" : [
                     {
+                        "name" : "numId",
+                        "in" : "query",
+                        "description" : "numId field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "integer",
+                            "format" : "int64"
+                        }
+                    },
+                    {
                         "name" : "effectiveDate",
                         "in" : "query",
                         "description" : "effectiveDate field value.",
@@ -8658,16 +10935,6 @@
                         "allowEmptyValue" : false,
                         "schema" : {
                             "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "numId",
-                        "in" : "query",
-                        "description" : "numId field value.",
-                        "allowEmptyValue" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int64"
                         }
                     }
                 ],
@@ -8813,7 +11080,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateTypedCompositeKeyEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateTypedCompositeKeyEntityRequest"
+                                }
                             }
                         }
                     }
@@ -8859,7 +11129,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateTypedCompositeKeyEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateTypedCompositeKeyEntityRequest"
+                                }
                             }
                         }
                     }
@@ -8928,6 +11201,604 @@
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/TypedCompositeKeyEntityKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AnnotatedPerson" : {
+            "get" : {
+                "tags" : [
+                    "AnnotatedPerson"
+                ],
+                "summary" : "Get a(n) AnnotatedPerson",
+                "operationId" : "GetAnnotatedPerson",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredAnnotatedPersonResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AnnotatedPerson/$query" : {
+            "post" : {
+                "tags" : [
+                    "AnnotatedPerson"
+                ],
+                "summary" : "Filter AnnotatedPerson",
+                "operationId" : "QueryAnnotatedPerson",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredAnnotatedPersonResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AnnotatedPerson/$create" : {
+            "post" : {
+                "tags" : [
+                    "AnnotatedPerson"
+                ],
+                "summary" : "Bulk create AnnotatedPerson",
+                "operationId" : "BulkCreateAnnotatedPerson",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateAnnotatedPersonRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateAnnotatedPersonResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AnnotatedPersonKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AnnotatedPerson/$update" : {
+            "put" : {
+                "tags" : [
+                    "AnnotatedPerson"
+                ],
+                "summary" : "Replace a(n) AnnotatedPerson",
+                "operationId" : "ReplaceAnnotatedPerson",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAnnotatedPersonRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateAnnotatedPersonResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "AnnotatedPerson"
+                ],
+                "summary" : "Partially update a(n) AnnotatedPerson",
+                "operationId" : "UpdateAnnotatedPerson",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateAnnotatedPersonRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateAnnotatedPersonResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AnnotatedPerson"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/AnnotatedPerson/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "AnnotatedPerson"
+                ],
+                "summary" : "Bulk delete AnnotatedPerson",
+                "operationId" : "BulkDeleteAnnotatedPerson",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/AnnotatedPersonKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteAnnotatedPersonResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/AnnotatedPersonKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Note" : {
+            "get" : {
+                "tags" : [
+                    "Note"
+                ],
+                "summary" : "Get a(n) Note",
+                "operationId" : "GetNote",
+                "parameters" : [
+                    {
+                        "name" : "id",
+                        "in" : "query",
+                        "description" : "id field value.",
+                        "allowEmptyValue" : false,
+                        "schema" : {
+                            "type" : "string"
+                        }
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredNoteResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Note"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Note/$query" : {
+            "post" : {
+                "tags" : [
+                    "Note"
+                ],
+                "summary" : "Filter Note",
+                "operationId" : "QueryNote",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "example" : "{\n    \"$from\": \"Resource\",\n    \"$where\": {\n        \"id\": \"abcd-efgh\",\n        \"cost\": {\n            \"$eq\": \"0\",\n            \"$ne\": \"0\",\n            \"$lt\": \"0\",\n            \"$gt\": \"0\",\n            \"$matches\": \"cat*\",\n            \"$in\": [\n                0,\n                2,\n                1\n            ],\n            \"$nin\": [\n                0,\n                1\n            ]\n        },\n        \"$and\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ],\n        \"$or\": [\n            {\n                \"id\": \"1\"\n            },\n            {\n                \"desc\": \"desc1\"\n            }\n        ]\n    },\n    \"$orderBy\": {\n        \"id\": \"ASC\"\n    },\n    \"$expand\": [\n        \"relation\"\n    ],\n    \"$page\": {\n        \"$index\": 0,\n        \"$size\": 100\n    }\n}"
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful fetch.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "FilteredNoteResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Note"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Note/$create" : {
+            "post" : {
+                "tags" : [
+                    "Note"
+                ],
+                "summary" : "Bulk create Note",
+                "operationId" : "BulkCreateNote",
+                "requestBody" : {
+                    "description" : "Fields needed for creation",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/CreateNoteRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful creation.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkCreateNoteResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/NoteKey"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Note/$update" : {
+            "put" : {
+                "tags" : [
+                    "Note"
+                ],
+                "summary" : "Replace a(n) Note",
+                "operationId" : "ReplaceNote",
+                "requestBody" : {
+                    "description" : "Complete representation of the resource",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateNoteRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful replace.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateNoteResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Note"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch" : {
+                "tags" : [
+                    "Note"
+                ],
+                "summary" : "Partially update a(n) Note",
+                "operationId" : "UpdateNote",
+                "requestBody" : {
+                    "description" : "Fields to update (partial)",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateNoteRequest"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful update.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "UpdateNoteResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Note"
+                                            }
+                                        },
+                                        "pageSize" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        },
+                                        "pageIndex" : {
+                                            "type" : "integer",
+                                            "format" : "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/speedy/v1/Note/$delete" : {
+            "delete" : {
+                "tags" : [
+                    "Note"
+                ],
+                "summary" : "Bulk delete Note",
+                "operationId" : "BulkDeleteNote",
+                "requestBody" : {
+                    "description" : "Fields needed for deletion",
+                    "content" : {
+                        "application/json;charset=UTF-8" : {
+                            "schema" : {
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/NoteKey"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses" : {
+                    "200" : {
+                        "description" : "successful deletion.",
+                        "content" : {
+                            "application/json;charset=UTF-8" : {
+                                "schema" : {
+                                    "title" : "BulkDeleteNoteResponse",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "payload" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/NoteKey"
                                             }
                                         },
                                         "pageSize" : {
@@ -9106,7 +11977,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateFkNullEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateFkNullEntityRequest"
+                                }
                             }
                         }
                     }
@@ -9152,7 +12026,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateFkNullEntityRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateFkNullEntityRequest"
+                                }
                             }
                         }
                     }
@@ -9399,7 +12276,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateInventoryRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateInventoryRequest"
+                                }
                             }
                         }
                     }
@@ -9445,7 +12325,10 @@
                     "content" : {
                         "application/json;charset=UTF-8" : {
                             "schema" : {
-                                "$ref" : "#/components/schemas/UpdateInventoryRequest"
+                                "type" : "array",
+                                "items" : {
+                                    "$ref" : "#/components/schemas/UpdateInventoryRequest"
+                                }
                             }
                         }
                     }
@@ -9538,6 +12421,12 @@
             "ValueTestEntity" : {
                 "type" : "object",
                 "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "localDateTime" : {
+                        "type" : "string"
+                    },
                     "localDate" : {
                         "type" : "string"
                     },
@@ -9547,17 +12436,11 @@
                     "instantTime" : {
                         "type" : "string"
                     },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "localDateTime" : {
+                    "zonedDateTime" : {
                         "type" : "string"
                     },
                     "booleanValue" : {
                         "type" : "boolean"
-                    },
-                    "zonedDateTime" : {
-                        "type" : "string"
                     },
                     "doubleValue" : {
                         "type" : "number",
@@ -9579,6 +12462,9 @@
             "CreateValueTestEntityRequest" : {
                 "type" : "object",
                 "properties" : {
+                    "localDateTime" : {
+                        "type" : "string"
+                    },
                     "localDate" : {
                         "type" : "string"
                     },
@@ -9588,14 +12474,11 @@
                     "instantTime" : {
                         "type" : "string"
                     },
-                    "localDateTime" : {
+                    "zonedDateTime" : {
                         "type" : "string"
                     },
                     "booleanValue" : {
                         "type" : "boolean"
-                    },
-                    "zonedDateTime" : {
-                        "type" : "string"
                     },
                     "doubleValue" : {
                         "type" : "number",
@@ -9609,6 +12492,12 @@
                 ],
                 "type" : "object",
                 "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "localDateTime" : {
+                        "type" : "string"
+                    },
                     "localDate" : {
                         "type" : "string"
                     },
@@ -9618,17 +12507,11 @@
                     "instantTime" : {
                         "type" : "string"
                     },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "localDateTime" : {
+                    "zonedDateTime" : {
                         "type" : "string"
                     },
                     "booleanValue" : {
                         "type" : "boolean"
-                    },
-                    "zonedDateTime" : {
-                        "type" : "string"
                     },
                     "doubleValue" : {
                         "type" : "number",
@@ -9636,106 +12519,16 @@
                     }
                 }
             },
-            "ExchangeRate" : {
-                "type" : "object",
-                "properties" : {
-                    "exchangeRate" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "invExchangeRate" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
-                    },
-                    "baseCurrency" : {
-                        "$ref" : "#/components/schemas/Currency"
-                    },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "foreignCurrency" : {
-                        "$ref" : "#/components/schemas/Currency"
-                    }
-                }
-            },
-            "ExchangeRateKey" : {
-                "required" : [
-                    "id"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "id" : {
-                        "type" : "string"
-                    }
-                }
-            },
-            "CreateExchangeRateRequest" : {
-                "required" : [
-                    "exchangeRate",
-                    "invExchangeRate",
-                    "baseCurrency",
-                    "foreignCurrency"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "exchangeRate" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "invExchangeRate" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "baseCurrency" : {
-                        "$ref" : "#/components/schemas/CurrencyKey"
-                    },
-                    "foreignCurrency" : {
-                        "$ref" : "#/components/schemas/CurrencyKey"
-                    }
-                }
-            },
-            "UpdateExchangeRateRequest" : {
-                "required" : [
-                    "exchangeRate",
-                    "invExchangeRate",
-                    "baseCurrency",
-                    "id",
-                    "foreignCurrency"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "exchangeRate" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "invExchangeRate" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "baseCurrency" : {
-                        "$ref" : "#/components/schemas/CurrencyKey"
-                    },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "foreignCurrency" : {
-                        "$ref" : "#/components/schemas/CurrencyKey"
-                    }
-                }
-            },
             "Task" : {
                 "type" : "object",
                 "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
                     "title" : {
                         "type" : "string"
                     },
                     "priority" : {
-                        "type" : "string"
-                    },
-                    "id" : {
                         "type" : "string"
                     },
                     "difficulty" : {
@@ -9775,20 +12568,20 @@
             },
             "UpdateTaskRequest" : {
                 "required" : [
+                    "id",
                     "title",
                     "priority",
-                    "id",
                     "difficulty"
                 ],
                 "type" : "object",
                 "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
                     "title" : {
                         "type" : "string"
                     },
                     "priority" : {
-                        "type" : "string"
-                    },
-                    "id" : {
                         "type" : "string"
                     },
                     "difficulty" : {
@@ -9796,51 +12589,185 @@
                     }
                 }
             },
-            "Company" : {
+            "ExchangeRate" : {
                 "type" : "object",
                 "properties" : {
-                    "deletedAt" : {
-                        "type" : "string"
-                    },
-                    "detailsTop" : {
-                        "type" : "string"
-                    },
-                    "status" : {
-                        "type" : "string"
-                    },
-                    "defaultGenerator" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "extra" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "string"
                     },
+                    "baseCurrency" : {
+                        "$ref" : "#/components/schemas/Currency"
+                    },
+                    "foreignCurrency" : {
+                        "$ref" : "#/components/schemas/Currency"
+                    },
+                    "exchangeRate" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "invExchangeRate" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
                     "createdAt" : {
                         "type" : "string"
+                    }
+                }
+            },
+            "ExchangeRateKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateExchangeRateRequest" : {
+                "required" : [
+                    "baseCurrency",
+                    "foreignCurrency",
+                    "exchangeRate",
+                    "invExchangeRate"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "baseCurrency" : {
+                        "$ref" : "#/components/schemas/CurrencyKey"
                     },
-                    "email" : {
+                    "foreignCurrency" : {
+                        "$ref" : "#/components/schemas/CurrencyKey"
+                    },
+                    "exchangeRate" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "invExchangeRate" : {
+                        "type" : "number",
+                        "format" : "double"
+                    }
+                }
+            },
+            "UpdateExchangeRateRequest" : {
+                "required" : [
+                    "id",
+                    "baseCurrency",
+                    "foreignCurrency",
+                    "exchangeRate",
+                    "invExchangeRate"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "baseCurrency" : {
+                        "$ref" : "#/components/schemas/CurrencyKey"
+                    },
+                    "foreignCurrency" : {
+                        "$ref" : "#/components/schemas/CurrencyKey"
+                    },
+                    "exchangeRate" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "invExchangeRate" : {
+                        "type" : "number",
+                        "format" : "double"
+                    }
+                }
+            },
+            "SuffixedFkEntity" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "productId" : {
+                        "$ref" : "#/components/schemas/PkUuidTest"
+                    }
+                }
+            },
+            "SuffixedFkEntityKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateSuffixedFkEntityRequest" : {
+                "type" : "object",
+                "properties" : {
+                    "productId" : {
+                        "$ref" : "#/components/schemas/PkUuidTestKey"
+                    }
+                }
+            },
+            "UpdateSuffixedFkEntityRequest" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "productId" : {
+                        "$ref" : "#/components/schemas/PkUuidTestKey"
+                    }
+                }
+            },
+            "Company" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
+                    "address" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "phone" : {
+                        "type" : "string"
+                    },
+                    "detailsTop" : {
+                        "type" : "string"
+                    },
+                    "extra" : {
+                        "type" : "string"
+                    },
                     "currency" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "status" : {
                         "type" : "string"
                     },
                     "invoiceNo" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
-                    "phone" : {
+                    "defaultGenerator" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "createdAt" : {
                         "type" : "string"
                     },
                     "updatedAt" : {
+                        "type" : "string"
+                    },
+                    "deletedAt" : {
                         "type" : "string"
                     }
                 }
@@ -9858,382 +12785,111 @@
             },
             "CreateCompanyRequest" : {
                 "required" : [
-                    "status",
                     "name",
-                    "currency",
                     "address",
-                    "phone"
+                    "phone",
+                    "currency",
+                    "status"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "deletedAt" : {
+                    "name" : {
                         "type" : "string"
                     },
-                    "detailsTop" : {
-                        "type" : "string"
-                    },
-                    "status" : {
-                        "type" : "string"
-                    },
-                    "defaultGenerator" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "extra" : {
-                        "type" : "string"
-                    },
-                    "createdAt" : {
+                    "address" : {
                         "type" : "string"
                     },
                     "email" : {
                         "type" : "string"
                     },
-                    "name" : {
+                    "phone" : {
+                        "type" : "string"
+                    },
+                    "detailsTop" : {
+                        "type" : "string"
+                    },
+                    "extra" : {
                         "type" : "string"
                     },
                     "currency" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "status" : {
                         "type" : "string"
                     },
                     "invoiceNo" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
-                    "phone" : {
+                    "defaultGenerator" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "createdAt" : {
                         "type" : "string"
                     },
                     "updatedAt" : {
+                        "type" : "string"
+                    },
+                    "deletedAt" : {
                         "type" : "string"
                     }
                 }
             },
             "UpdateCompanyRequest" : {
                 "required" : [
-                    "status",
                     "id",
                     "name",
-                    "currency",
                     "address",
-                    "phone"
+                    "phone",
+                    "currency",
+                    "status"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "deletedAt" : {
-                        "type" : "string"
-                    },
-                    "detailsTop" : {
-                        "type" : "string"
-                    },
-                    "status" : {
-                        "type" : "string"
-                    },
-                    "defaultGenerator" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "extra" : {
-                        "type" : "string"
-                    },
                     "id" : {
-                        "type" : "string"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
-                    },
-                    "email" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
+                    "address" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "phone" : {
+                        "type" : "string"
+                    },
+                    "detailsTop" : {
+                        "type" : "string"
+                    },
+                    "extra" : {
+                        "type" : "string"
+                    },
                     "currency" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "status" : {
                         "type" : "string"
                     },
                     "invoiceNo" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
-                    "phone" : {
+                    "defaultGenerator" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "createdAt" : {
                         "type" : "string"
                     },
                     "updatedAt" : {
-                        "type" : "string"
-                    }
-                }
-            },
-            "Invoice" : {
-                "type" : "object",
-                "properties" : {
-                    "notes" : {
-                        "type" : "string"
-                    },
-                    "createdBy" : {
-                        "type" : "string"
-                    },
-                    "customer" : {
-                        "$ref" : "#/components/schemas/Customer"
-                    },
-                    "adjustment" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "dueAmount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "modifiedAt" : {
-                        "type" : "string"
-                    },
-                    "invoiceDate" : {
-                        "type" : "string"
-                    },
-                    "paid" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
-                    },
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "modifiedBy" : {
-                        "type" : "string"
-                    }
-                }
-            },
-            "InvoiceKey" : {
-                "required" : [
-                    "id"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "id" : {
-                        "type" : "string"
-                    }
-                }
-            },
-            "CreateInvoiceRequest" : {
-                "required" : [
-                    "customer",
-                    "adjustment",
-                    "dueAmount",
-                    "invoiceDate",
-                    "paid",
-                    "discount"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "notes" : {
-                        "type" : "string"
-                    },
-                    "createdBy" : {
-                        "type" : "string"
-                    },
-                    "customer" : {
-                        "$ref" : "#/components/schemas/CustomerKey"
-                    },
-                    "adjustment" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "dueAmount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "modifiedAt" : {
-                        "type" : "string"
-                    },
-                    "invoiceDate" : {
-                        "type" : "string"
-                    },
-                    "paid" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
-                    },
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "modifiedBy" : {
-                        "type" : "string"
-                    }
-                }
-            },
-            "UpdateInvoiceRequest" : {
-                "required" : [
-                    "customer",
-                    "adjustment",
-                    "id",
-                    "dueAmount",
-                    "invoiceDate",
-                    "paid",
-                    "discount"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "notes" : {
-                        "type" : "string"
-                    },
-                    "createdBy" : {
-                        "type" : "string"
-                    },
-                    "customer" : {
-                        "$ref" : "#/components/schemas/CustomerKey"
-                    },
-                    "adjustment" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "dueAmount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "modifiedAt" : {
-                        "type" : "string"
-                    },
-                    "invoiceDate" : {
-                        "type" : "string"
-                    },
-                    "paid" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
-                    },
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "modifiedBy" : {
-                        "type" : "string"
-                    }
-                }
-            },
-            "User" : {
-                "type" : "object",
-                "properties" : {
-                    "email" : {
-                        "type" : "string"
-                    },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "lastLoginDate" : {
-                        "type" : "string"
-                    },
-                    "phoneNo" : {
-                        "type" : "string"
-                    },
-                    "type" : {
                         "type" : "string"
                     },
                     "deletedAt" : {
                         "type" : "string"
-                    },
-                    "name" : {
-                        "type" : "string"
-                    },
-                    "updatedAt" : {
-                        "type" : "string"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
-                    },
-                    "loginCount" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    }
-                }
-            },
-            "UserKey" : {
-                "required" : [
-                    "id"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "id" : {
-                        "type" : "string"
-                    }
-                }
-            },
-            "CreateUserRequest" : {
-                "required" : [
-                    "email",
-                    "phoneNo",
-                    "type",
-                    "name"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "email" : {
-                        "type" : "string"
-                    },
-                    "lastLoginDate" : {
-                        "type" : "string"
-                    },
-                    "phoneNo" : {
-                        "type" : "string"
-                    },
-                    "type" : {
-                        "type" : "string"
-                    },
-                    "name" : {
-                        "type" : "string"
-                    },
-                    "loginCount" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    }
-                }
-            },
-            "UpdateUserRequest" : {
-                "required" : [
-                    "email",
-                    "id",
-                    "phoneNo",
-                    "type",
-                    "name"
-                ],
-                "type" : "object",
-                "properties" : {
-                    "email" : {
-                        "type" : "string"
-                    },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "lastLoginDate" : {
-                        "type" : "string"
-                    },
-                    "phoneNo" : {
-                        "type" : "string"
-                    },
-                    "type" : {
-                        "type" : "string"
-                    },
-                    "name" : {
-                        "type" : "string"
-                    },
-                    "loginCount" : {
-                        "type" : "integer",
-                        "format" : "int64"
                     }
                 }
             },
@@ -10285,31 +12941,302 @@
                     }
                 }
             },
-            "Customer" : {
+            "Invoice" : {
                 "type" : "object",
                 "properties" : {
-                    "phoneNo" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "customer" : {
+                        "$ref" : "#/components/schemas/Customer"
+                    },
+                    "paid" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "adjustment" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "dueAmount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "notes" : {
+                        "type" : "string"
+                    },
+                    "invoiceDate" : {
+                        "type" : "string"
+                    },
+                    "createdAt" : {
                         "type" : "string"
                     },
                     "createdBy" : {
                         "type" : "string"
                     },
-                    "email" : {
+                    "modifiedAt" : {
                         "type" : "string"
                     },
+                    "modifiedBy" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "InvoiceKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateInvoiceRequest" : {
+                "required" : [
+                    "customer",
+                    "paid",
+                    "discount",
+                    "adjustment",
+                    "dueAmount",
+                    "invoiceDate"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "customer" : {
+                        "$ref" : "#/components/schemas/CustomerKey"
+                    },
+                    "paid" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "adjustment" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "dueAmount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "notes" : {
+                        "type" : "string"
+                    },
+                    "invoiceDate" : {
+                        "type" : "string"
+                    },
+                    "createdAt" : {
+                        "type" : "string"
+                    },
+                    "createdBy" : {
+                        "type" : "string"
+                    },
+                    "modifiedAt" : {
+                        "type" : "string"
+                    },
+                    "modifiedBy" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "UpdateInvoiceRequest" : {
+                "required" : [
+                    "id",
+                    "customer",
+                    "paid",
+                    "discount",
+                    "adjustment",
+                    "dueAmount",
+                    "invoiceDate"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "customer" : {
+                        "$ref" : "#/components/schemas/CustomerKey"
+                    },
+                    "paid" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "adjustment" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "dueAmount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "notes" : {
+                        "type" : "string"
+                    },
+                    "invoiceDate" : {
+                        "type" : "string"
+                    },
+                    "createdAt" : {
+                        "type" : "string"
+                    },
+                    "createdBy" : {
+                        "type" : "string"
+                    },
+                    "modifiedAt" : {
+                        "type" : "string"
+                    },
+                    "modifiedBy" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "User" : {
+                "type" : "object",
+                "properties" : {
                     "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
+                    "phoneNo" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "type" : {
+                        "type" : "string"
+                    },
                     "createdAt" : {
+                        "type" : "string"
+                    },
+                    "updatedAt" : {
+                        "type" : "string"
+                    },
+                    "deletedAt" : {
+                        "type" : "string"
+                    },
+                    "lastLoginDate" : {
+                        "type" : "string"
+                    },
+                    "loginCount" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    }
+                }
+            },
+            "UserKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateUserRequest" : {
+                "required" : [
+                    "name",
+                    "phoneNo",
+                    "email",
+                    "type"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "phoneNo" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "type" : {
+                        "type" : "string"
+                    },
+                    "lastLoginDate" : {
+                        "type" : "string"
+                    },
+                    "loginCount" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    }
+                }
+            },
+            "UpdateUserRequest" : {
+                "required" : [
+                    "id",
+                    "name",
+                    "phoneNo",
+                    "email",
+                    "type"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "phoneNo" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "type" : {
+                        "type" : "string"
+                    },
+                    "lastLoginDate" : {
+                        "type" : "string"
+                    },
+                    "loginCount" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    }
+                }
+            },
+            "Customer" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "address" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "phoneNo" : {
                         "type" : "string"
                     },
                     "altPhoneNo" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "createdAt" : {
+                        "type" : "string"
+                    },
+                    "createdBy" : {
                         "type" : "string"
                     }
                 }
@@ -10327,58 +13254,117 @@
             },
             "CreateCustomerRequest" : {
                 "required" : [
-                    "phoneNo",
-                    "name"
+                    "name",
+                    "phoneNo"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "phoneNo" : {
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "address" : {
                         "type" : "string"
                     },
                     "email" : {
                         "type" : "string"
                     },
-                    "name" : {
-                        "type" : "string"
-                    },
-                    "createdAt" : {
+                    "phoneNo" : {
                         "type" : "string"
                     },
                     "altPhoneNo" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "createdAt" : {
                         "type" : "string"
                     }
                 }
             },
             "UpdateCustomerRequest" : {
                 "required" : [
-                    "phoneNo",
                     "id",
-                    "name"
+                    "name",
+                    "phoneNo"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "phoneNo" : {
-                        "type" : "string"
-                    },
-                    "email" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "createdAt" : {
+                    "address" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "phoneNo" : {
                         "type" : "string"
                     },
                     "altPhoneNo" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "createdAt" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "Article" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "title" : {
+                        "type" : "string"
+                    },
+                    "status" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "ArticleKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateArticleRequest" : {
+                "required" : [
+                    "title",
+                    "status"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "title" : {
+                        "type" : "string"
+                    },
+                    "status" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "UpdateArticleRequest" : {
+                "required" : [
+                    "id",
+                    "title",
+                    "status"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "title" : {
+                        "type" : "string"
+                    },
+                    "status" : {
                         "type" : "string"
                     }
                 }
@@ -10434,13 +13420,13 @@
             "PkUuidTest" : {
                 "type" : "object",
                 "properties" : {
-                    "description" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "description" : {
                         "type" : "string"
                     }
                 }
@@ -10462,29 +13448,113 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "description" : {
+                    "name" : {
                         "type" : "string"
                     },
-                    "name" : {
+                    "description" : {
                         "type" : "string"
                     }
                 }
             },
             "UpdatePkUuidTestRequest" : {
                 "required" : [
-                    "name",
-                    "id"
+                    "id",
+                    "name"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "description" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
+                    "description" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "ScalarFkEntity" : {
+                "type" : "object",
+                "properties" : {
                     "id" : {
                         "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "ref" : {
+                        "$ref" : "#/components/schemas/PkUuidTest"
+                    },
+                    "refByName" : {
+                        "$ref" : "#/components/schemas/PkUuidTest"
+                    },
+                    "catRef" : {
+                        "$ref" : "#/components/schemas/Category"
+                    },
+                    "numRef" : {
+                        "$ref" : "#/components/schemas/AutoGenIdentityEntity"
+                    }
+                }
+            },
+            "ScalarFkEntityKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateScalarFkEntityRequest" : {
+                "required" : [
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "ref" : {
+                        "$ref" : "#/components/schemas/PkUuidTestKey"
+                    },
+                    "refByName" : {
+                        "$ref" : "#/components/schemas/PkUuidTestKey"
+                    },
+                    "catRef" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
+                    },
+                    "numRef" : {
+                        "$ref" : "#/components/schemas/AutoGenIdentityEntityKey"
+                    }
+                }
+            },
+            "UpdateScalarFkEntityRequest" : {
+                "required" : [
+                    "id",
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "ref" : {
+                        "$ref" : "#/components/schemas/PkUuidTestKey"
+                    },
+                    "refByName" : {
+                        "$ref" : "#/components/schemas/PkUuidTestKey"
+                    },
+                    "catRef" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
+                    },
+                    "numRef" : {
+                        "$ref" : "#/components/schemas/AutoGenIdentityEntityKey"
                     }
                 }
             },
@@ -10494,14 +13564,14 @@
                     "id" : {
                         "type" : "string"
                     },
+                    "name" : {
+                        "type" : "string"
+                    },
                     "description" : {
                         "type" : "string"
                     },
                     "category" : {
                         "$ref" : "#/components/schemas/Category"
-                    },
-                    "name" : {
-                        "type" : "string"
                     }
                 }
             },
@@ -10518,31 +13588,34 @@
             },
             "CreateProductRequest" : {
                 "required" : [
-                    "category",
-                    "name"
+                    "name",
+                    "category"
                 ],
                 "type" : "object",
                 "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    },
                     "description" : {
                         "type" : "string"
                     },
                     "category" : {
                         "$ref" : "#/components/schemas/CategoryKey"
-                    },
-                    "name" : {
-                        "type" : "string"
                     }
                 }
             },
             "UpdateProductRequest" : {
                 "required" : [
                     "id",
-                    "category",
-                    "name"
+                    "name",
+                    "category"
                 ],
                 "type" : "object",
                 "properties" : {
                     "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
                         "type" : "string"
                     },
                     "description" : {
@@ -10550,19 +13623,16 @@
                     },
                     "category" : {
                         "$ref" : "#/components/schemas/CategoryKey"
-                    },
-                    "name" : {
-                        "type" : "string"
                     }
                 }
             },
             "EntityWithIgnoredField" : {
                 "type" : "object",
                 "properties" : {
-                    "visibleField" : {
+                    "id" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "visibleField" : {
                         "type" : "string"
                     }
                 }
@@ -10591,15 +13661,15 @@
             },
             "UpdateEntityWithIgnoredFieldRequest" : {
                 "required" : [
-                    "visibleField",
-                    "id"
+                    "id",
+                    "visibleField"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "visibleField" : {
+                    "id" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "visibleField" : {
                         "type" : "string"
                     }
                 }
@@ -10607,12 +13677,12 @@
             "AutoGenAutoEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "name" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "integer",
                         "format" : "int64"
+                    },
+                    "name" : {
+                        "type" : "string"
                     }
                 }
             },
@@ -10641,17 +13711,76 @@
             },
             "UpdateAutoGenAutoEntityRequest" : {
                 "required" : [
-                    "name",
+                    "id",
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "Document" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "title" : {
+                        "type" : "string"
+                    },
+                    "owner" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "DocumentKey" : {
+                "required" : [
                     "id"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "name" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateDocumentRequest" : {
+                "required" : [
+                    "title",
+                    "owner"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "title" : {
                         "type" : "string"
                     },
+                    "owner" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "UpdateDocumentRequest" : {
+                "required" : [
+                    "id",
+                    "title",
+                    "owner"
+                ],
+                "type" : "object",
+                "properties" : {
                     "id" : {
-                        "type" : "integer",
-                        "format" : "int64"
+                        "type" : "string"
+                    },
+                    "title" : {
+                        "type" : "string"
+                    },
+                    "owner" : {
+                        "type" : "string"
                     }
                 }
             },
@@ -10661,15 +13790,15 @@
                     "id" : {
                         "type" : "string"
                     },
+                    "custom_name" : {
+                        "type" : "string"
+                    },
                     "custom_cost" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
                     "custom_category" : {
                         "$ref" : "#/components/schemas/Category"
-                    },
-                    "custom_name" : {
-                        "type" : "string"
                     }
                 }
             },
@@ -10687,15 +13816,15 @@
             "CreateJsonPropertyEntityRequest" : {
                 "type" : "object",
                 "properties" : {
+                    "custom_name" : {
+                        "type" : "string"
+                    },
                     "custom_cost" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
                     "custom_category" : {
                         "$ref" : "#/components/schemas/CategoryKey"
-                    },
-                    "custom_name" : {
-                        "type" : "string"
                     }
                 }
             },
@@ -10708,25 +13837,25 @@
                     "id" : {
                         "type" : "string"
                     },
+                    "custom_name" : {
+                        "type" : "string"
+                    },
                     "custom_cost" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
                     "custom_category" : {
                         "$ref" : "#/components/schemas/CategoryKey"
-                    },
-                    "custom_name" : {
-                        "type" : "string"
                     }
                 }
             },
             "BulkDisabledEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "name" : {
+                    "id" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "name" : {
                         "type" : "string"
                     }
                 }
@@ -10755,15 +13884,15 @@
             },
             "UpdateBulkDisabledEntityRequest" : {
                 "required" : [
-                    "name",
-                    "id"
+                    "id",
+                    "name"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "name" : {
+                    "id" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "name" : {
                         "type" : "string"
                     }
                 }
@@ -10771,13 +13900,13 @@
             "VirtualEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "description" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "description" : {
                         "type" : "string"
                     }
                 }
@@ -10796,13 +13925,13 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "description" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "description" : {
                         "type" : "string"
                     }
                 }
@@ -10813,13 +13942,13 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "description" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "description" : {
                         "type" : "string"
                     }
                 }
@@ -10827,12 +13956,12 @@
             "AutoGenIdentityEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "name" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "integer",
                         "format" : "int64"
+                    },
+                    "name" : {
+                        "type" : "string"
                     }
                 }
             },
@@ -10861,35 +13990,83 @@
             },
             "UpdateAutoGenIdentityEntityRequest" : {
                 "required" : [
-                    "name",
+                    "id",
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "AliasedCategoryRefEntity" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "cat" : {
+                        "$ref" : "#/components/schemas/Category"
+                    }
+                }
+            },
+            "AliasedCategoryRefEntityKey" : {
+                "required" : [
                     "id"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "name" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateAliasedCategoryRefEntityRequest" : {
+                "required" : [
+                    "cat"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "cat" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
+                    }
+                }
+            },
+            "UpdateAliasedCategoryRefEntityRequest" : {
+                "required" : [
+                    "id",
+                    "cat"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
                         "type" : "string"
                     },
-                    "id" : {
-                        "type" : "integer",
-                        "format" : "int64"
+                    "cat" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
                     }
                 }
             },
             "SensitiveTestEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "amount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "publicField" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "string"
                     },
                     "secretField" : {
                         "type" : "string"
+                    },
+                    "publicField" : {
+                        "type" : "string"
+                    },
+                    "amount" : {
+                        "type" : "number",
+                        "format" : "double"
                     }
                 }
             },
@@ -10907,15 +14084,15 @@
             "CreateSensitiveTestEntityRequest" : {
                 "type" : "object",
                 "properties" : {
-                    "amount" : {
-                        "type" : "number",
-                        "format" : "double"
+                    "secretField" : {
+                        "type" : "string"
                     },
                     "publicField" : {
                         "type" : "string"
                     },
-                    "secretField" : {
-                        "type" : "string"
+                    "amount" : {
+                        "type" : "number",
+                        "format" : "double"
                     }
                 }
             },
@@ -10925,17 +14102,65 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "amount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "publicField" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "string"
                     },
                     "secretField" : {
+                        "type" : "string"
+                    },
+                    "publicField" : {
+                        "type" : "string"
+                    },
+                    "amount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    }
+                }
+            },
+            "BulkCreateOnlyEntity" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "BulkCreateOnlyEntityKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateBulkCreateOnlyEntityRequest" : {
+                "required" : [
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "UpdateBulkCreateOnlyEntityRequest" : {
+                "required" : [
+                    "id",
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
                         "type" : "string"
                     }
                 }
@@ -10943,13 +14168,7 @@
             "Currency" : {
                 "type" : "object",
                 "properties" : {
-                    "createdAt" : {
-                        "type" : "string"
-                    },
                     "id" : {
-                        "type" : "string"
-                    },
-                    "currencyAbbr" : {
                         "type" : "string"
                     },
                     "currencyName" : {
@@ -10958,7 +14177,13 @@
                     "currencySymbol" : {
                         "type" : "string"
                     },
+                    "currencyAbbr" : {
+                        "type" : "string"
+                    },
                     "country" : {
+                        "type" : "string"
+                    },
+                    "createdAt" : {
                         "type" : "string"
                     }
                 }
@@ -10976,19 +14201,19 @@
             },
             "CreateCurrencyRequest" : {
                 "required" : [
-                    "currencyAbbr",
                     "currencyName",
-                    "currencySymbol"
+                    "currencySymbol",
+                    "currencyAbbr"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "currencyAbbr" : {
-                        "type" : "string"
-                    },
                     "currencyName" : {
                         "type" : "string"
                     },
                     "currencySymbol" : {
+                        "type" : "string"
+                    },
+                    "currencyAbbr" : {
                         "type" : "string"
                     },
                     "country" : {
@@ -10999,22 +14224,22 @@
             "UpdateCurrencyRequest" : {
                 "required" : [
                     "id",
-                    "currencyAbbr",
                     "currencyName",
-                    "currencySymbol"
+                    "currencySymbol",
+                    "currencyAbbr"
                 ],
                 "type" : "object",
                 "properties" : {
                     "id" : {
                         "type" : "string"
                     },
-                    "currencyAbbr" : {
-                        "type" : "string"
-                    },
                     "currencyName" : {
                         "type" : "string"
                     },
                     "currencySymbol" : {
+                        "type" : "string"
+                    },
+                    "currencyAbbr" : {
                         "type" : "string"
                     },
                     "country" : {
@@ -11025,13 +14250,13 @@
             "SensitiveClassEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "fieldB" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "fieldA" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "fieldB" : {
                         "type" : "string"
                     }
                 }
@@ -11050,10 +14275,10 @@
             "CreateSensitiveClassEntityRequest" : {
                 "type" : "object",
                 "properties" : {
-                    "fieldB" : {
+                    "fieldA" : {
                         "type" : "string"
                     },
-                    "fieldA" : {
+                    "fieldB" : {
                         "type" : "string"
                     }
                 }
@@ -11064,13 +14289,13 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "fieldB" : {
+                    "id" : {
                         "type" : "string"
                     },
                     "fieldA" : {
                         "type" : "string"
                     },
-                    "id" : {
+                    "fieldB" : {
                         "type" : "string"
                     }
                 }
@@ -11078,28 +14303,28 @@
             "Supplier" : {
                 "type" : "object",
                 "properties" : {
-                    "phoneNo" : {
-                        "type" : "string"
-                    },
-                    "createdBy" : {
-                        "type" : "string"
-                    },
-                    "email" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "createdAt" : {
+                    "address" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "phoneNo" : {
                         "type" : "string"
                     },
                     "altPhoneNo" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "createdAt" : {
+                        "type" : "string"
+                    },
+                    "createdBy" : {
                         "type" : "string"
                     }
                 }
@@ -11117,95 +14342,152 @@
             },
             "CreateSupplierRequest" : {
                 "required" : [
-                    "phoneNo",
                     "name",
+                    "phoneNo",
                     "altPhoneNo"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "phoneNo" : {
+                    "name" : {
                         "type" : "string"
                     },
-                    "createdBy" : {
+                    "address" : {
                         "type" : "string"
                     },
                     "email" : {
                         "type" : "string"
                     },
-                    "name" : {
-                        "type" : "string"
-                    },
-                    "createdAt" : {
+                    "phoneNo" : {
                         "type" : "string"
                     },
                     "altPhoneNo" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "createdAt" : {
+                        "type" : "string"
+                    },
+                    "createdBy" : {
                         "type" : "string"
                     }
                 }
             },
             "UpdateSupplierRequest" : {
                 "required" : [
-                    "phoneNo",
                     "id",
                     "name",
+                    "phoneNo",
                     "altPhoneNo"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "phoneNo" : {
-                        "type" : "string"
-                    },
-                    "createdBy" : {
-                        "type" : "string"
-                    },
-                    "email" : {
-                        "type" : "string"
-                    },
                     "id" : {
                         "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "createdAt" : {
+                    "address" : {
+                        "type" : "string"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "phoneNo" : {
                         "type" : "string"
                     },
                     "altPhoneNo" : {
                         "type" : "string"
                     },
-                    "address" : {
+                    "createdAt" : {
                         "type" : "string"
+                    },
+                    "createdBy" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "RenamedScalarFkEntity" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "cat" : {
+                        "$ref" : "#/components/schemas/Category"
+                    }
+                }
+            },
+            "RenamedScalarFkEntityKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateRenamedScalarFkEntityRequest" : {
+                "required" : [
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "cat" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
+                    }
+                }
+            },
+            "UpdateRenamedScalarFkEntityRequest" : {
+                "required" : [
+                    "id",
+                    "name"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "cat" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
                     }
                 }
             },
             "Order" : {
                 "type" : "object",
                 "properties" : {
-                    "supplier" : {
-                        "$ref" : "#/components/schemas/Supplier"
+                    "productId" : {
+                        "type" : "string"
+                    },
+                    "supplierId" : {
+                        "type" : "string"
+                    },
+                    "orderDate" : {
+                        "type" : "string"
                     },
                     "price" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "orderDate" : {
-                        "type" : "string"
-                    },
                     "discount" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "productId" : {
-                        "type" : "string"
-                    },
                     "product" : {
                         "$ref" : "#/components/schemas/Product"
                     },
-                    "supplierId" : {
-                        "type" : "string"
+                    "supplier" : {
+                        "$ref" : "#/components/schemas/Supplier"
                     }
                 }
             },
@@ -11231,22 +14513,22 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "price" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "orderDate" : {
-                        "type" : "string"
-                    },
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "productId" : {
                         "type" : "string"
                     },
                     "supplierId" : {
                         "type" : "string"
+                    },
+                    "orderDate" : {
+                        "type" : "string"
+                    },
+                    "price" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
                     }
                 }
             },
@@ -11257,59 +14539,59 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "price" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "orderDate" : {
-                        "type" : "string"
-                    },
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "productId" : {
                         "type" : "string"
                     },
                     "supplierId" : {
                         "type" : "string"
+                    },
+                    "orderDate" : {
+                        "type" : "string"
+                    },
+                    "price" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
                     }
                 }
             },
             "Procurement" : {
                 "type" : "object",
                 "properties" : {
-                    "createdBy" : {
-                        "type" : "string"
-                    },
                     "id" : {
-                        "type" : "string"
-                    },
-                    "supplier" : {
-                        "$ref" : "#/components/schemas/Supplier"
-                    },
-                    "modifiedAt" : {
-                        "type" : "string"
-                    },
-                    "purchaseDate" : {
-                        "type" : "string"
-                    },
-                    "modifiedBy" : {
                         "type" : "string"
                     },
                     "product" : {
                         "$ref" : "#/components/schemas/Product"
                     },
-                    "dueAmount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
+                    "supplier" : {
+                        "$ref" : "#/components/schemas/Supplier"
                     },
                     "amount" : {
                         "type" : "number",
                         "format" : "double"
+                    },
+                    "dueAmount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "purchaseDate" : {
+                        "type" : "string"
+                    },
+                    "createdAt" : {
+                        "type" : "string"
+                    },
+                    "createdBy" : {
+                        "type" : "string"
+                    },
+                    "modifiedAt" : {
+                        "type" : "string"
+                    },
+                    "modifiedBy" : {
+                        "type" : "string"
                     }
                 }
             },
@@ -11326,101 +14608,101 @@
             },
             "CreateProcurementRequest" : {
                 "required" : [
-                    "supplier",
-                    "purchaseDate",
                     "product",
+                    "supplier",
+                    "amount",
                     "dueAmount",
-                    "amount"
+                    "purchaseDate"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "createdBy" : {
-                        "type" : "string"
+                    "product" : {
+                        "$ref" : "#/components/schemas/ProductKey"
                     },
                     "supplier" : {
                         "$ref" : "#/components/schemas/SupplierKey"
                     },
-                    "modifiedAt" : {
-                        "type" : "string"
-                    },
-                    "purchaseDate" : {
-                        "type" : "string"
-                    },
-                    "modifiedBy" : {
-                        "type" : "string"
-                    },
-                    "product" : {
-                        "$ref" : "#/components/schemas/ProductKey"
+                    "amount" : {
+                        "type" : "number",
+                        "format" : "double"
                     },
                     "dueAmount" : {
                         "type" : "number",
                         "format" : "double"
                     },
+                    "purchaseDate" : {
+                        "type" : "string"
+                    },
                     "createdAt" : {
                         "type" : "string"
                     },
-                    "amount" : {
-                        "type" : "number",
-                        "format" : "double"
+                    "createdBy" : {
+                        "type" : "string"
+                    },
+                    "modifiedAt" : {
+                        "type" : "string"
+                    },
+                    "modifiedBy" : {
+                        "type" : "string"
                     }
                 }
             },
             "UpdateProcurementRequest" : {
                 "required" : [
                     "id",
-                    "supplier",
-                    "purchaseDate",
                     "product",
+                    "supplier",
+                    "amount",
                     "dueAmount",
-                    "amount"
+                    "purchaseDate"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "createdBy" : {
-                        "type" : "string"
-                    },
                     "id" : {
-                        "type" : "string"
-                    },
-                    "supplier" : {
-                        "$ref" : "#/components/schemas/SupplierKey"
-                    },
-                    "modifiedAt" : {
-                        "type" : "string"
-                    },
-                    "purchaseDate" : {
-                        "type" : "string"
-                    },
-                    "modifiedBy" : {
                         "type" : "string"
                     },
                     "product" : {
                         "$ref" : "#/components/schemas/ProductKey"
                     },
-                    "dueAmount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "createdAt" : {
-                        "type" : "string"
+                    "supplier" : {
+                        "$ref" : "#/components/schemas/SupplierKey"
                     },
                     "amount" : {
                         "type" : "number",
                         "format" : "double"
+                    },
+                    "dueAmount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "purchaseDate" : {
+                        "type" : "string"
+                    },
+                    "createdAt" : {
+                        "type" : "string"
+                    },
+                    "createdBy" : {
+                        "type" : "string"
+                    },
+                    "modifiedAt" : {
+                        "type" : "string"
+                    },
+                    "modifiedBy" : {
+                        "type" : "string"
                     }
                 }
             },
             "SensitiveFkEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "sensitiveTestEntity" : {
-                        "$ref" : "#/components/schemas/SensitiveTestEntity"
+                    "id" : {
+                        "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
-                        "type" : "string"
+                    "sensitiveTestEntity" : {
+                        "$ref" : "#/components/schemas/SensitiveTestEntity"
                     }
                 }
             },
@@ -11441,48 +14723,48 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "sensitiveTestEntity" : {
-                        "$ref" : "#/components/schemas/SensitiveTestEntityKey"
-                    },
                     "name" : {
                         "type" : "string"
+                    },
+                    "sensitiveTestEntity" : {
+                        "$ref" : "#/components/schemas/SensitiveTestEntityKey"
                     }
                 }
             },
             "UpdateSensitiveFkEntityRequest" : {
                 "required" : [
-                    "sensitiveTestEntity",
-                    "id"
+                    "id",
+                    "sensitiveTestEntity"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "sensitiveTestEntity" : {
-                        "$ref" : "#/components/schemas/SensitiveTestEntityKey"
+                    "id" : {
+                        "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
-                        "type" : "string"
+                    "sensitiveTestEntity" : {
+                        "$ref" : "#/components/schemas/SensitiveTestEntityKey"
                     }
                 }
             },
             "TypeOverrideEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "textField" : {
+                    "id" : {
                         "type" : "string"
                     },
-                    "floatField" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "id" : {
+                    "textField" : {
                         "type" : "string"
                     },
                     "bigIntField" : {
                         "type" : "integer",
                         "format" : "int64"
+                    },
+                    "floatField" : {
+                        "type" : "number",
+                        "format" : "double"
                     }
                 }
             },
@@ -11503,13 +14785,13 @@
                     "textField" : {
                         "type" : "string"
                     },
-                    "floatField" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "bigIntField" : {
                         "type" : "integer",
                         "format" : "int64"
+                    },
+                    "floatField" : {
+                        "type" : "number",
+                        "format" : "double"
                     }
                 }
             },
@@ -11519,40 +14801,43 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "textField" : {
+                    "id" : {
                         "type" : "string"
                     },
-                    "floatField" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "id" : {
+                    "textField" : {
                         "type" : "string"
                     },
                     "bigIntField" : {
                         "type" : "integer",
                         "format" : "int64"
+                    },
+                    "floatField" : {
+                        "type" : "number",
+                        "format" : "double"
                     }
                 }
             },
             "PriceHistory" : {
                 "type" : "object",
                 "properties" : {
+                    "productId" : {
+                        "type" : "string"
+                    },
+                    "effectiveAt" : {
+                        "type" : "string"
+                    },
                     "price" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "productId" : {
+                    "note" : {
                         "type" : "string"
                     },
-                    "note" : {
+                    "lastModifiedAt" : {
                         "type" : "string"
                     },
                     "product" : {
                         "$ref" : "#/components/schemas/Product"
-                    },
-                    "effectiveAt" : {
-                        "type" : "string"
                     }
                 }
             },
@@ -11578,17 +14863,17 @@
                 ],
                 "type" : "object",
                 "properties" : {
+                    "productId" : {
+                        "type" : "string"
+                    },
+                    "effectiveAt" : {
+                        "type" : "string"
+                    },
                     "price" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "productId" : {
-                        "type" : "string"
-                    },
                     "note" : {
-                        "type" : "string"
-                    },
-                    "effectiveAt" : {
                         "type" : "string"
                     }
                 }
@@ -11600,17 +14885,17 @@
                 ],
                 "type" : "object",
                 "properties" : {
+                    "productId" : {
+                        "type" : "string"
+                    },
+                    "effectiveAt" : {
+                        "type" : "string"
+                    },
                     "price" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "productId" : {
-                        "type" : "string"
-                    },
                     "note" : {
-                        "type" : "string"
-                    },
-                    "effectiveAt" : {
                         "type" : "string"
                     }
                 }
@@ -11679,52 +14964,10 @@
                     }
                 }
             },
-            "AnnotatedPerson" : {
+            "Employee" : {
                 "type" : "object",
                 "properties" : {
-                    "precisionVal" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "age" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "email" : {
-                        "type" : "string"
-                    },
-                    "rating" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "id" : {
-                        "type" : "string"
-                    },
-                    "website" : {
-                        "type" : "string"
-                    },
-                    "bookingDate" : {
-                        "type" : "string"
-                    },
-                    "debt" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "score" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "appointmentDate" : {
-                        "type" : "string"
-                    },
-                    "birthDate" : {
-                        "type" : "string"
-                    },
-                    "overdraft" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "code" : {
                         "type" : "string"
                     },
                     "name" : {
@@ -11733,13 +14976,10 @@
                     "salary" : {
                         "type" : "number",
                         "format" : "double"
-                    },
-                    "isoDate" : {
-                        "type" : "string"
                     }
                 }
             },
-            "AnnotatedPersonKey" : {
+            "EmployeeKey" : {
                 "required" : [
                     "id"
                 ],
@@ -11750,134 +14990,31 @@
                     }
                 }
             },
-            "CreateAnnotatedPersonRequest" : {
+            "CreateEmployeeRequest" : {
                 "required" : [
-                    "precisionVal",
-                    "age",
-                    "email",
-                    "rating",
-                    "debt",
-                    "score",
-                    "overdraft",
-                    "code",
                     "name",
                     "salary"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "precisionVal" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "age" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "email" : {
-                        "type" : "string"
-                    },
-                    "rating" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "website" : {
-                        "type" : "string"
-                    },
-                    "bookingDate" : {
-                        "type" : "string"
-                    },
-                    "debt" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "score" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "appointmentDate" : {
-                        "type" : "string"
-                    },
-                    "birthDate" : {
-                        "type" : "string"
-                    },
-                    "overdraft" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "code" : {
-                        "type" : "string"
-                    },
                     "name" : {
                         "type" : "string"
                     },
                     "salary" : {
                         "type" : "number",
                         "format" : "double"
-                    },
-                    "isoDate" : {
-                        "type" : "string"
                     }
                 }
             },
-            "UpdateAnnotatedPersonRequest" : {
+            "UpdateEmployeeRequest" : {
                 "required" : [
-                    "precisionVal",
-                    "age",
-                    "email",
-                    "rating",
                     "id",
-                    "debt",
-                    "score",
-                    "overdraft",
-                    "code",
                     "name",
                     "salary"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "precisionVal" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "age" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "email" : {
-                        "type" : "string"
-                    },
-                    "rating" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "id" : {
-                        "type" : "string"
-                    },
-                    "website" : {
-                        "type" : "string"
-                    },
-                    "bookingDate" : {
-                        "type" : "string"
-                    },
-                    "debt" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "score" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "appointmentDate" : {
-                        "type" : "string"
-                    },
-                    "birthDate" : {
-                        "type" : "string"
-                    },
-                    "overdraft" : {
-                        "type" : "integer",
-                        "format" : "int64"
-                    },
-                    "code" : {
                         "type" : "string"
                     },
                     "name" : {
@@ -11886,9 +15023,6 @@
                     "salary" : {
                         "type" : "number",
                         "format" : "double"
-                    },
-                    "isoDate" : {
-                        "type" : "string"
                     }
                 }
             },
@@ -11898,14 +15032,14 @@
                     "sensorId" : {
                         "type" : "string"
                     },
-                    "label" : {
+                    "recordedAt" : {
                         "type" : "string"
                     },
                     "temperature" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "recordedAt" : {
+                    "label" : {
                         "type" : "string"
                     }
                 }
@@ -11935,14 +15069,14 @@
                     "sensorId" : {
                         "type" : "string"
                     },
-                    "label" : {
+                    "recordedAt" : {
                         "type" : "string"
                     },
                     "temperature" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "recordedAt" : {
+                    "label" : {
                         "type" : "string"
                     }
                 }
@@ -11957,14 +15091,14 @@
                     "sensorId" : {
                         "type" : "string"
                     },
-                    "label" : {
+                    "recordedAt" : {
                         "type" : "string"
                     },
                     "temperature" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "recordedAt" : {
+                    "label" : {
                         "type" : "string"
                     }
                 }
@@ -11972,26 +15106,26 @@
             "TypedCompositeKeyEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "amount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "numId" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
-                    "code" : {
+                    "effectiveDate" : {
                         "type" : "string"
                     },
-                    "active" : {
-                        "type" : "boolean"
-                    },
-                    "effectiveDate" : {
+                    "code" : {
                         "type" : "string"
                     },
                     "quantity" : {
                         "type" : "integer",
                         "format" : "int64"
+                    },
+                    "amount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "active" : {
+                        "type" : "boolean"
                     },
                     "description" : {
                         "type" : "string"
@@ -12001,8 +15135,8 @@
             "TypedCompositeKeyEntityKey" : {
                 "required" : [
                     "numId",
-                    "code",
-                    "effectiveDate"
+                    "effectiveDate",
+                    "code"
                 ],
                 "type" : "object",
                 "properties" : {
@@ -12010,10 +15144,10 @@
                         "type" : "integer",
                         "format" : "int64"
                     },
-                    "code" : {
+                    "effectiveDate" : {
                         "type" : "string"
                     },
-                    "effectiveDate" : {
+                    "code" : {
                         "type" : "string"
                     }
                 }
@@ -12021,31 +15155,31 @@
             "CreateTypedCompositeKeyEntityRequest" : {
                 "required" : [
                     "numId",
-                    "code",
-                    "effectiveDate"
+                    "effectiveDate",
+                    "code"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "amount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "numId" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
-                    "code" : {
+                    "effectiveDate" : {
                         "type" : "string"
                     },
-                    "active" : {
-                        "type" : "boolean"
-                    },
-                    "effectiveDate" : {
+                    "code" : {
                         "type" : "string"
                     },
                     "quantity" : {
                         "type" : "integer",
                         "format" : "int64"
+                    },
+                    "amount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "active" : {
+                        "type" : "boolean"
                     },
                     "description" : {
                         "type" : "string"
@@ -12055,33 +15189,297 @@
             "UpdateTypedCompositeKeyEntityRequest" : {
                 "required" : [
                     "numId",
-                    "code",
-                    "effectiveDate"
+                    "effectiveDate",
+                    "code"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "amount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "numId" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
-                    "code" : {
+                    "effectiveDate" : {
                         "type" : "string"
                     },
-                    "active" : {
-                        "type" : "boolean"
-                    },
-                    "effectiveDate" : {
+                    "code" : {
                         "type" : "string"
                     },
                     "quantity" : {
                         "type" : "integer",
                         "format" : "int64"
                     },
+                    "amount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "active" : {
+                        "type" : "boolean"
+                    },
                     "description" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "AnnotatedPerson" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "age" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "code" : {
+                        "type" : "string"
+                    },
+                    "salary" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "score" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "debt" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "overdraft" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "rating" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "precisionVal" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "website" : {
+                        "type" : "string"
+                    },
+                    "birthDate" : {
+                        "type" : "string"
+                    },
+                    "appointmentDate" : {
+                        "type" : "string"
+                    },
+                    "bookingDate" : {
+                        "type" : "string"
+                    },
+                    "isoDate" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "AnnotatedPersonKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateAnnotatedPersonRequest" : {
+                "required" : [
+                    "name",
+                    "age",
+                    "email",
+                    "code",
+                    "salary",
+                    "score",
+                    "debt",
+                    "overdraft",
+                    "rating",
+                    "precisionVal"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "age" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "code" : {
+                        "type" : "string"
+                    },
+                    "salary" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "score" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "debt" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "overdraft" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "rating" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "precisionVal" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "website" : {
+                        "type" : "string"
+                    },
+                    "birthDate" : {
+                        "type" : "string"
+                    },
+                    "appointmentDate" : {
+                        "type" : "string"
+                    },
+                    "bookingDate" : {
+                        "type" : "string"
+                    },
+                    "isoDate" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "UpdateAnnotatedPersonRequest" : {
+                "required" : [
+                    "id",
+                    "name",
+                    "age",
+                    "email",
+                    "code",
+                    "salary",
+                    "score",
+                    "debt",
+                    "overdraft",
+                    "rating",
+                    "precisionVal"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "type" : "string"
+                    },
+                    "age" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "email" : {
+                        "type" : "string"
+                    },
+                    "code" : {
+                        "type" : "string"
+                    },
+                    "salary" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "score" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "debt" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "overdraft" : {
+                        "type" : "integer",
+                        "format" : "int64"
+                    },
+                    "rating" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "precisionVal" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "website" : {
+                        "type" : "string"
+                    },
+                    "birthDate" : {
+                        "type" : "string"
+                    },
+                    "appointmentDate" : {
+                        "type" : "string"
+                    },
+                    "bookingDate" : {
+                        "type" : "string"
+                    },
+                    "isoDate" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "Note" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "title" : {
+                        "type" : "string"
+                    },
+                    "rowVersion" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "NoteKey" : {
+                "required" : [
+                    "id"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "CreateNoteRequest" : {
+                "required" : [
+                    "title"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "title" : {
+                        "type" : "string"
+                    }
+                }
+            },
+            "UpdateNoteRequest" : {
+                "required" : [
+                    "id",
+                    "title"
+                ],
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string"
+                    },
+                    "title" : {
                         "type" : "string"
                     }
                 }
@@ -12089,14 +15487,14 @@
             "FkNullEntity" : {
                 "type" : "object",
                 "properties" : {
-                    "category" : {
-                        "$ref" : "#/components/schemas/Category"
+                    "id" : {
+                        "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
-                        "type" : "string"
+                    "category" : {
+                        "$ref" : "#/components/schemas/Category"
                     }
                 }
             },
@@ -12117,40 +15515,42 @@
                 ],
                 "type" : "object",
                 "properties" : {
-                    "category" : {
-                        "$ref" : "#/components/schemas/CategoryKey"
-                    },
                     "name" : {
                         "type" : "string"
+                    },
+                    "category" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
                     }
                 }
             },
             "UpdateFkNullEntityRequest" : {
                 "required" : [
-                    "name",
-                    "id"
+                    "id",
+                    "name"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "category" : {
-                        "$ref" : "#/components/schemas/CategoryKey"
+                    "id" : {
+                        "type" : "string"
                     },
                     "name" : {
                         "type" : "string"
                     },
-                    "id" : {
-                        "type" : "string"
+                    "category" : {
+                        "$ref" : "#/components/schemas/CategoryKey"
                     }
                 }
             },
             "Inventory" : {
                 "type" : "object",
                 "properties" : {
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
+                    "id" : {
+                        "type" : "string"
                     },
-                    "soldPrice" : {
+                    "product" : {
+                        "$ref" : "#/components/schemas/Product"
+                    },
+                    "cost" : {
                         "type" : "number",
                         "format" : "double"
                     },
@@ -12158,21 +15558,19 @@
                         "type" : "number",
                         "format" : "double"
                     },
-                    "invoice" : {
-                        "$ref" : "#/components/schemas/Invoice"
-                    },
-                    "cost" : {
+                    "soldPrice" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "id" : {
-                        "type" : "string"
-                    },
-                    "product" : {
-                        "$ref" : "#/components/schemas/Product"
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
                     },
                     "procurement" : {
                         "$ref" : "#/components/schemas/Procurement"
+                    },
+                    "invoice" : {
+                        "$ref" : "#/components/schemas/Invoice"
                     }
                 }
             },
@@ -12189,21 +15587,20 @@
             },
             "CreateInventoryRequest" : {
                 "required" : [
-                    "discount",
-                    "soldPrice",
-                    "listingPrice",
-                    "invoice",
-                    "cost",
                     "product",
-                    "procurement"
+                    "cost",
+                    "listingPrice",
+                    "soldPrice",
+                    "discount",
+                    "procurement",
+                    "invoice"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
+                    "product" : {
+                        "$ref" : "#/components/schemas/ProductKey"
                     },
-                    "soldPrice" : {
+                    "cost" : {
                         "type" : "number",
                         "format" : "double"
                     },
@@ -12211,61 +15608,62 @@
                         "type" : "number",
                         "format" : "double"
                     },
-                    "invoice" : {
-                        "$ref" : "#/components/schemas/InvoiceKey"
-                    },
-                    "cost" : {
+                    "soldPrice" : {
                         "type" : "number",
                         "format" : "double"
                     },
-                    "product" : {
-                        "$ref" : "#/components/schemas/ProductKey"
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
                     },
                     "procurement" : {
                         "$ref" : "#/components/schemas/ProcurementKey"
+                    },
+                    "invoice" : {
+                        "$ref" : "#/components/schemas/InvoiceKey"
                     }
                 }
             },
             "UpdateInventoryRequest" : {
                 "required" : [
-                    "discount",
-                    "soldPrice",
-                    "listingPrice",
-                    "invoice",
-                    "cost",
                     "id",
                     "product",
-                    "procurement"
+                    "cost",
+                    "listingPrice",
+                    "soldPrice",
+                    "discount",
+                    "procurement",
+                    "invoice"
                 ],
                 "type" : "object",
                 "properties" : {
-                    "discount" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "soldPrice" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "listingPrice" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
-                    "invoice" : {
-                        "$ref" : "#/components/schemas/InvoiceKey"
-                    },
-                    "cost" : {
-                        "type" : "number",
-                        "format" : "double"
-                    },
                     "id" : {
                         "type" : "string"
                     },
                     "product" : {
                         "$ref" : "#/components/schemas/ProductKey"
                     },
+                    "cost" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "listingPrice" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "soldPrice" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
+                    "discount" : {
+                        "type" : "number",
+                        "format" : "double"
+                    },
                     "procurement" : {
                         "$ref" : "#/components/schemas/ProcurementKey"
+                    },
+                    "invoice" : {
+                        "$ref" : "#/components/schemas/InvoiceKey"
                     }
                 }
             }

--- a/speedy-test-app/pom.xml
+++ b/speedy-test-app/pom.xml
@@ -179,6 +179,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/RenamedScalarFkEntity.java
+++ b/speedy-test-app/src/main/java/com/github/silent/samurai/speedy/entity/RenamedScalarFkEntity.java
@@ -1,0 +1,36 @@
+package com.github.silent.samurai.speedy.entity;
+
+import com.github.silent.samurai.speedy.annotations.SpeedyAssociation;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+// The realistic @SpeedyAssociation shape: a legacy scalar FK whose Java field is named after the
+// column it maps ("catId"), not after the reference it becomes. Left as-is the association would be
+// exposed as "catId" and followed as "catId.id" -- the Id suffix lying about a property that is now
+// an object. name() renames it to what a @ManyToOne field would have been called, so it reads
+// "cat.id", identical to AliasedCategoryRefEntity's native relationship.
+//
+// Kept off ScalarFkEntity deliberately: that entity's Category-targeting field (catRef) must stay
+// the only one for AssociationNameFallbackTest's unambiguous-entity-name case.
+@Getter
+@Setter
+@Table(name = "RENAMED_SCALAR_FK_ENTITY")
+@Entity
+public class RenamedScalarFkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    protected UUID id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "cat_id", nullable = true)
+    @SpeedyAssociation(value = Category.class, name = "cat")
+    private String catId;
+
+}

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/SpeedyAssociationRenameTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/entity/SpeedyAssociationRenameTest.java
@@ -1,0 +1,171 @@
+package com.github.silent.samurai.speedy.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.silent.samurai.speedy.SpeedyFactory;
+import com.github.silent.samurai.speedy.TestApplication;
+import com.github.silent.samurai.speedy.client.test.SpeedyTest;
+import com.github.silent.samurai.speedy.exceptions.NotFoundException;
+import com.github.silent.samurai.speedy.interfaces.metadata.FieldMetadata;
+import com.github.silent.samurai.speedy.interfaces.metadata.MetaModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.condition;
+import static com.github.silent.samurai.speedy.client.SpeedyQuery.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Covers @SpeedyAssociation#name() on RenamedScalarFkEntity.catId -> "cat". A scalar FK is
+// conventionally named after its column ("catId"), but the annotation turns it into an object
+// reference, so without the rename it would be exposed -- and navigated -- as "catId.id". The
+// rename has to hold across every surface the output property name feeds: the metamodel, the
+// generated OpenAPI schemas, write payloads, read payloads, and $filter navigation.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SpeedyAssociationRenameTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private SpeedyFactory speedyFactory;
+
+    private SpeedyTest speedyClient;
+
+    @BeforeEach
+    void setUp() {
+        speedyClient = SpeedyTest.mockMvc(mvc);
+    }
+
+    private String createCategory() {
+        return speedyClient.create("Category")
+                .field("name", "cat-" + UUID.randomUUID())
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+    }
+
+    private JsonNode schemas() throws Exception {
+        String json = mvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+        return MAPPER.readTree(json).path("components").path("schemas");
+    }
+
+    @Test
+    void metamodel_exposesRenamedProperty_notTheJavaFieldName() throws NotFoundException {
+        MetaModel metaModel = speedyFactory.getMetaModel();
+        FieldMetadata field = metaModel.findFieldMetadata("RenamedScalarFkEntity", "cat");
+
+        assertThat(field.isAssociation()).isTrue();
+        assertThat(field.getAssociationMetadata().getName()).isEqualTo("Category");
+        assertThat(field.getAssociatedFieldMetadata().getOutputPropertyName()).isEqualTo("id");
+        // The DB column is untouched -- only the exposed property name changes.
+        assertThat(field.getDbColumnName()).isEqualTo("cat_id");
+    }
+
+    @Test
+    void metamodel_javaFieldName_isNoLongerAddressable() {
+        MetaModel metaModel = speedyFactory.getMetaModel();
+
+        assertThatThrownBy(() -> metaModel.findFieldMetadata("RenamedScalarFkEntity", "catId"))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void openApi_schemasExposeRenamedPropertyAsRefToTarget() throws Exception {
+        JsonNode schemas = schemas();
+
+        // Every generated schema the field qualifies for -- it's serializable, insertable and
+        // updatable, so all but the key-only schema carry it. The response schema refs the full
+        // target entity while the request schemas ref its key-only form (OASGenerator.ENTITY_NAME
+        // vs ENTITY_KEY in SpeedyOpenApiCustomizer#createSchemas).
+        Map<String, String> expectedRefBySchema = Map.of(
+                "RenamedScalarFkEntity", "#/components/schemas/Category",
+                "CreateRenamedScalarFkEntityRequest", "#/components/schemas/CategoryKey",
+                "UpdateRenamedScalarFkEntityRequest", "#/components/schemas/CategoryKey");
+
+        for (Map.Entry<String, String> expected : expectedRefBySchema.entrySet()) {
+            String schemaName = expected.getKey();
+            JsonNode properties = schemas.path(schemaName).path("properties");
+            assertThat(properties.has("cat"))
+                    .as("%s should expose the renamed property 'cat'", schemaName)
+                    .isTrue();
+            assertThat(properties.has("catId"))
+                    .as("%s should not expose the Java field name 'catId'", schemaName)
+                    .isFalse();
+
+            // An association renders as a $ref, never as the scalar column's own type -- the whole
+            // reason the "catId" name read wrong in the first place.
+            assertThat(properties.path("cat").path("$ref").asText())
+                    .as("%s.properties.cat should $ref the target entity", schemaName)
+                    .isEqualTo(expected.getValue());
+        }
+    }
+
+    @Test
+    void create_andRead_useRenamedProperty() {
+        String categoryId = createCategory();
+
+        String sourceId = speedyClient.create("RenamedScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("cat.id", categoryId)
+                .execute()
+                .expectOk()
+                .jsonPath("$.payload[0].id");
+
+        speedyClient.get("RenamedScalarFkEntity")
+                .key("id", sourceId)
+                .execute()
+                .expectOk()
+                .expectJsonPath("$.payload[0].cat.id", categoryId)
+                .expectJsonPathDoesNotExist("$.payload[0].catId");
+    }
+
+    @Test
+    void query_filterNavigatesThroughRenamedProperty() {
+        String categoryId = createCategory();
+
+        speedyClient.create("RenamedScalarFkEntity")
+                .field("name", "source-" + UUID.randomUUID())
+                .field("cat.id", categoryId)
+                .execute()
+                .expectOk();
+
+        speedyClient.query("RenamedScalarFkEntity")
+                .where(condition("cat.id", eq(categoryId)))
+                .execute()
+                .expectOk()
+                .expectJsonPathExists("$.payload[0].id");
+    }
+
+    @Test
+    void metamodel_renameDoesNotLeakIntoOtherEntities() throws NotFoundException {
+        // ScalarFkEntity leaves its @SpeedyAssociation fields unrenamed -- name() is opt-in, and a
+        // blank default must keep the Java field name.
+        MetaModel metaModel = speedyFactory.getMetaModel();
+        List<String> properties = metaModel.findEntityMetadata("ScalarFkEntity").getAllFields()
+                .stream()
+                .map(FieldMetadata::getOutputPropertyName)
+                .collect(Collectors.toList());
+
+        assertThat(properties).contains("ref", "refByName", "catRef", "numRef");
+    }
+}

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/url/SpeedyCompositeKeyTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/url/SpeedyCompositeKeyTest.java
@@ -150,7 +150,7 @@ class SpeedyCompositeKeyTest {
         request.setSupplierId(key.getSupplierId());
         request.setDiscount(100.0);
 
-        UpdateOrderResponse response = apiInstance.updateOrder(request);
+        UpdateOrderResponse response = apiInstance.updateOrder(List.of(request));
         List<Order> payload = response.getPayload();
         Assertions.assertNotNull(payload);
         Assertions.assertFalse(payload.isEmpty());

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/url/SpeedyEntityTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/url/SpeedyEntityTest.java
@@ -393,7 +393,7 @@ class SpeedyEntityTest {
         updateCurrencyRequest.setId(currencyKey.getId());
 
         UpdateCurrencyResponse updateCurrency200Response = currencyApi
-                .updateCurrency(updateCurrencyRequest);
+                .updateCurrency(List.of(updateCurrencyRequest));
 
         Assertions.assertNotNull(updateCurrency200Response);
         Assertions.assertNotNull(updateCurrency200Response.getPayload());

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/url/SpeedyPutTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/url/SpeedyPutTest.java
@@ -101,7 +101,7 @@ public class SpeedyPutTest {
         UpdateProductRequest productRequest = new UpdateProductRequest();
         productRequest.setId("7");
         productRequest.setCategory(new CategoryKey().id("1"));
-        UpdateProductResponse response = productApi.updateProduct(productRequest);
+        UpdateProductResponse response = productApi.updateProduct(List.of(productRequest));
         assertNotNull(response);
         assertNotNull(response.getPayload());
         assertFalse(response.getPayload().isEmpty());
@@ -130,7 +130,7 @@ public class SpeedyPutTest {
             UpdateCategoryRequest categoryRequest = new UpdateCategoryRequest();
             String value = CommonUtil.generateString(300);
             categoryRequest.setName(value);
-            UpdateCategoryResponse response = categoryApi.updateCategory(categoryRequest);
+            UpdateCategoryResponse response = categoryApi.updateCategory(List.of(categoryRequest));
             assertNotNull(response);
             assertNotNull(response.getPayload());
             List<org.openapitools.client.model.Category> payload = response.getPayload();
@@ -145,7 +145,7 @@ public class SpeedyPutTest {
             String value = CommonUtil.generateString(300);
             categoryRequest.setId("1");
             categoryRequest.setName(value);
-            UpdateCategoryResponse response = categoryApi.updateCategory(categoryRequest);
+            UpdateCategoryResponse response = categoryApi.updateCategory(List.of(categoryRequest));
             assertNotNull(response);
             assertNotNull(response.getPayload());
             List<org.openapitools.client.model.Category> payload = response.getPayload();


### PR DESCRIPTION
## Summary
- Add `@SpeedyAssociation#name()` so a manual scalar-FK association (e.g. `catId`) can be exposed under a sensible property name (`cat`) instead of the raw column-derived field name, consistent across JSON, the generated OpenAPI schema, and `$filter` navigation.
- Fix non-deterministic composite-key field/parameter ordering: `EntityBuilder`/`EntityMetadataImpl` used hash-bucket-ordered `Map`/`Set`s, so the generated OpenAPI client's positional method arguments (e.g. `getOrder(productId, supplierId)`) could silently reorder on regeneration with no compile error. Attributes are now sorted by declared field order and carried through with order-preserving collections.
- Regenerate `api-docs.json` and rebuild the OpenAPI client against the fix, updating stale `$update` call sites to the array-bodied form.

## Test plan
- [x] `mvn test` on `speedy-commons`, `speedy-mp-jpa`, `speedy-mp-json`, `speedy-test-app` — all green
- [x] Composite-key suites (`SpeedyCompositeKeyTest`, `SpeedyCompositeKeyPatchTest`, etc.) pass against the regenerated client
- [x] New `SpeedyAssociationRenameTest` covers the rename end-to-end (metamodel, OpenAPI schema, create/read, `$filter`)

