### PR TITLE
Batch foreign-key resolution during $expand

### DIFF
--- a/speedy-commons/src/main/java/com/github/silent/samurai/speedy/interfaces/backend/RowReader.java
+++ b/speedy-commons/src/main/java/com/github/silent/samurai/speedy/interfaces/backend/RowReader.java
@@ -1,6 +1,7 @@
 package com.github.silent.samurai.speedy.interfaces.backend;
 
 import com.github.silent.samurai.speedy.exceptions.SpeedyHttpException;
+import com.github.silent.samurai.speedy.interfaces.SpeedyValue;
 import com.github.silent.samurai.speedy.interfaces.metadata.FieldMetadata;
 import com.github.silent.samurai.speedy.interfaces.query.SpeedyQuery;
 import com.github.silent.samurai.speedy.models.SpeedyEntity;
@@ -8,7 +9,6 @@ import com.github.silent.samurai.speedy.models.SpeedyEntityKey;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Optional;
 
 /// Read/fetch half of the backend port. The format-agnostic
 /// {@code DefaultQueryProcessor} (in speedy-core) drives the
@@ -42,7 +42,12 @@ public interface RowReader {
         return !selectByKeys(List.of(key)).isEmpty();
     }
 
-    /// The single related row reached by following the foreign key of {@code association} from
-    /// {@code parentRow} (used during {@code $expand}); empty when the FK is null or unresolved.
-    Optional<SpeedyEntity> selectByFk(FieldMetadata association, SpeedyEntity parentRow) throws SpeedyHttpException;
+    /// Rows of {@code association}'s target whose associated field matches any of {@code fkValues}
+    /// — the batched foreign-key fetch that drives {@code $expand}. Returns an empty list for empty
+    /// input, and may return fewer rows than keys (an unmatched key resolves to null).
+    ///
+    /// The walker calls this once per expansion level for the whole result set, so a backend should
+    /// answer it with a single statement (an {@code IN} list or equivalent). Callers chunk the key
+    /// list, so an implementation need not split it further.
+    List<SpeedyEntity> selectByFks(FieldMetadata association, List<SpeedyValue> fkValues) throws SpeedyHttpException;
 }

--- a/speedy-core/src/main/java/com/github/silent/samurai/speedy/backend/DefaultQueryProcessor.java
+++ b/speedy-core/src/main/java/com/github/silent/samurai/speedy/backend/DefaultQueryProcessor.java
@@ -216,13 +216,11 @@ public class DefaultQueryProcessor implements QueryProcessor {
         backend.runInTransaction(block);
     }
 
-    /// Rebuilds each backend row into a {@link SpeedyEntity}, preserving the backend's row order.
+    /// Rebuilds the backend rows into {@link SpeedyEntity}s, preserving the backend's row order.
+    /// Handed to the walker as one batch so each `$expand` level costs a single fetch for the whole
+    /// result set rather than one per row.
     private List<SpeedyEntity> mapRows(List<SpeedyEntity> rows, SpeedyQuery query) throws SpeedyHttpException {
-        List<SpeedyEntity> list = new ArrayList<>(rows.size());
-        for (SpeedyEntity row : rows) {
-            list.add(recordToSpeedy.fromRow(row, query.getFrom(), query.getExpand()));
-        }
-        return list;
+        return recordToSpeedy.fromRows(rows, query.getFrom(), query.getExpand());
     }
 
     /// Refetches rows for the given keys and returns the rebuilt entities in the same order as

--- a/speedy-core/src/main/java/com/github/silent/samurai/speedy/backend/RecordToSpeedy.java
+++ b/speedy-core/src/main/java/com/github/silent/samurai/speedy/backend/RecordToSpeedy.java
@@ -14,6 +14,11 @@ import com.github.silent.samurai.speedy.models.SpeedyEntity;
 import com.github.silent.samurai.speedy.models.SpeedyEntityKey;
 import com.github.silent.samurai.speedy.utils.Speedy;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -27,9 +32,13 @@ import java.util.Set;
 /// The flat row is freshly built by the backend per record and used nowhere else, so enrichment is
 /// done **in place**, and the same instance is returned — no parallel tree is allocated. Purely
 /// structural: it reads already-decoded {@link SpeedyValue}s and navigates foreign keys via
-/// {@link RowReader#selectByFk}; value decoding lives in the backend port, so this walker holds no
+/// {@link RowReader#selectByFks}; value decoding lives in the backend port, so this walker holds no
 /// {@code TypeConverter}. Extracted from the former jOOQ {@code JooqSqlToSpeedy} with no behavioural change.
 public class RecordToSpeedy {
+
+    /// Upper bound on how many foreign keys go into a single fetch. Oracle rejects an IN list longer
+    /// than 1000 elements, and other backends have their own bind-parameter ceilings.
+    private static final int FK_BATCH_SIZE = 500;
 
     private final RowReader rowReader;
 
@@ -38,13 +47,29 @@ public class RecordToSpeedy {
     }
 
     public SpeedyEntity fromRow(SpeedyEntity row, EntityMetadata from, Set<String> expand) throws SpeedyHttpException {
-        ExpansionPathTracker pathTracker = new ExpansionPathTracker(expand);
-        return enrich(row, from, pathTracker);
+        return fromRows(List.of(row), from, expand).get(0);
     }
 
-    /// Enriches the flat {@code row} in place — resolving associations and back-filling any absent
-    /// scalar field with null — and returns the same instance.
-    private SpeedyEntity enrich(SpeedyEntity row, EntityMetadata entityMetadata, ExpansionPathTracker pathTracker) throws SpeedyHttpException {
+    /// Enriches every row of one result set together, so each `$expand` level costs one fetch for the
+    /// whole set rather than one per row. Rows are enriched in place and returned as the same list.
+    public List<SpeedyEntity> fromRows(List<SpeedyEntity> rows, EntityMetadata from, Set<String> expand)
+            throws SpeedyHttpException {
+        ExpansionPathTracker pathTracker = new ExpansionPathTracker(expand);
+        enrich(rows, from, pathTracker);
+        return rows;
+    }
+
+    /// Enriches the flat {@code rows} in place — resolving associations and back-filling any absent
+    /// scalar field with null.
+    ///
+    /// Walks breadth-first: every row at one position in the entity tree is processed together, so the
+    /// complete set of foreign keys for the next level is known before that level is fetched. A
+    /// depth-first walk cannot batch, because row 2's foreign key is not read until row 1 has already
+    /// been resolved to full depth.
+    private void enrich(List<SpeedyEntity> rows, EntityMetadata entityMetadata, ExpansionPathTracker pathTracker) throws SpeedyHttpException {
+        if (rows.isEmpty()) {
+            return;
+        }
         // Push the current entity onto the path tracker
         pathTracker.pushEntity(entityMetadata);
 
@@ -52,30 +77,13 @@ public class RecordToSpeedy {
             if (fieldMetadata.isAssociation()) {
                 // Check if this specific path should be expanded using dot notation
                 if (pathTracker.shouldExpand(fieldMetadata.getAssociationMetadata())) {
-                    // read the FK off the row, fetch the related row, then replace the FK with it
-                    Optional<SpeedyEntity> associatedRow = rowReader.selectByFk(fieldMetadata, row);
-                    // if fk is null
-                    if (associatedRow.isEmpty()) {
-                        row.put(fieldMetadata, Speedy.fromNull());
-                        continue;
-                    }
-                    if (fieldMetadata.isCollection()) {
-                        throw new NotImplementedException("Collection association expansion is not supported for field '"
-                                + fieldMetadata.getOutputPropertyName() + "' on entity '" + entityMetadata.getName() + "'");
-                    } else {
-                        EntityMetadata associationMetadata = fieldMetadata.getAssociationMetadata();
-                        SpeedyEntity associatedEntity = enrich(
-                                associatedRow.get(),
-                                associationMetadata,
-                                pathTracker
-                        );
-                        row.put(fieldMetadata, associatedEntity);
-                    }
+                    expandAssociation(rows, fieldMetadata, entityMetadata, pathTracker);
                 } else {
                     if (fieldMetadata.isCollection()) {
                         throw new NotImplementedException("Collection association key reference is not supported for field '"
                                 + fieldMetadata.getOutputPropertyName() + "' on entity '" + entityMetadata.getName() + "'");
-                    } else {
+                    }
+                    for (SpeedyEntity row : rows) {
                         Optional<SpeedyEntityKey> associatedEntityKey = createSpeedyKeyFromFK(row, fieldMetadata);
                         if (associatedEntityKey.isEmpty() || associatedEntityKey.get().isEmpty()) {
                             row.put(fieldMetadata, Speedy.fromNull());
@@ -84,15 +92,92 @@ public class RecordToSpeedy {
                         row.put(fieldMetadata, associatedEntityKey.get());
                     }
                 }
-            } else if (!row.has(fieldMetadata)) {
-                // scalar already present in the flat row; only back-fill the missing ones
-                row.put(fieldMetadata, Speedy.fromNull());
+            } else {
+                for (SpeedyEntity row : rows) {
+                    // scalar already present in the flat row; only back-fill the missing ones
+                    if (!row.has(fieldMetadata)) {
+                        row.put(fieldMetadata, Speedy.fromNull());
+                    }
+                }
             }
         }
 
         // Pop the current entity from the path tracker when done processing
         pathTracker.popEntity();
-        return row;
+    }
+
+    /// Resolves one expanded association for the whole row set: collect the distinct foreign keys,
+    /// fetch their targets in batches, enrich those targets (recursing a whole level at a time), then
+    /// replace each row's foreign key with the target it resolved to.
+    private void expandAssociation(List<SpeedyEntity> rows,
+                                   FieldMetadata association,
+                                   EntityMetadata entityMetadata,
+                                   ExpansionPathTracker pathTracker) throws SpeedyHttpException {
+        // LinkedHashSet: distinct keys, but a stable batch order so the emitted query is reproducible.
+        Set<SpeedyValue> distinctFks = new LinkedHashSet<>();
+        for (SpeedyEntity row : rows) {
+            SpeedyValue fk = foreignKeyOf(row, association);
+            if (fk != null) {
+                distinctFks.add(fk);
+            }
+        }
+
+        if (distinctFks.isEmpty()) {
+            // No row carries a foreign key — nothing to resolve, and nothing to fetch.
+            for (SpeedyEntity row : rows) {
+                row.put(association, Speedy.fromNull());
+            }
+            return;
+        }
+
+        if (association.isCollection()) {
+            throw new NotImplementedException("Collection association expansion is not supported for field '"
+                    + association.getOutputPropertyName() + "' on entity '" + entityMetadata.getName() + "'");
+        }
+
+        FieldMetadata associatedField = association.getAssociatedFieldMetadata();
+        Map<SpeedyValue, SpeedyEntity> targetsByFk = new HashMap<>();
+        List<SpeedyEntity> targets = new ArrayList<>();
+
+        // Chunked so the emitted IN list stays within backend limits (Oracle caps it at 1000 elements,
+        // and a page can carry more keys than that).
+        List<SpeedyValue> fkBatch = new ArrayList<>(distinctFks);
+        for (int start = 0; start < fkBatch.size(); start += FK_BATCH_SIZE) {
+            List<SpeedyValue> chunk = fkBatch.subList(start, Math.min(start + FK_BATCH_SIZE, fkBatch.size()));
+            for (SpeedyEntity target : rowReader.selectByFks(association, chunk)) {
+                if (!target.has(associatedField)) {
+                    continue;
+                }
+                // First row wins per foreign key, matching the single-row fetch this replaces.
+                if (targetsByFk.putIfAbsent(target.get(associatedField), target) == null) {
+                    targets.add(target);
+                }
+            }
+        }
+
+        // Recurse on the deduplicated targets, so the next level is also one fetch for the whole set.
+        enrich(targets, association.getAssociationMetadata(), pathTracker);
+
+        for (SpeedyEntity row : rows) {
+            SpeedyValue fk = foreignKeyOf(row, association);
+            SpeedyEntity target = fk == null ? null : targetsByFk.get(fk);
+            // An unresolved foreign key (absent column, SQL NULL, or no matching target row) reads as
+            // null, exactly as the per-row fetch did.
+            row.put(association, target == null ? Speedy.fromNull() : target);
+        }
+    }
+
+    /// The usable foreign-key value {@code association} carries on {@code row}, or null when the row
+    /// has no value to follow — the column was not selected, or it is SQL NULL.
+    private SpeedyValue foreignKeyOf(SpeedyEntity row, FieldMetadata association) {
+        if (!row.has(association)) {
+            return null;
+        }
+        SpeedyValue fk = row.get(association);
+        if (fk == null || fk.isNull() || fk.isEmpty()) {
+            return null;
+        }
+        return fk;
     }
 
     public Optional<SpeedyEntityKey> createSpeedyKeyFromFK(SpeedyEntity row, FieldMetadata fieldMetadata) throws SpeedyHttpException {

--- a/speedy-core/src/test/java/com/github/silent/samurai/speedy/backend/RecordToSpeedyBatchTest.java
+++ b/speedy-core/src/test/java/com/github/silent/samurai/speedy/backend/RecordToSpeedyBatchTest.java
@@ -1,0 +1,265 @@
+package com.github.silent.samurai.speedy.backend;
+
+import com.github.silent.samurai.speedy.enums.ColumnType;
+import com.github.silent.samurai.speedy.exceptions.SpeedyHttpException;
+import com.github.silent.samurai.speedy.interfaces.SpeedyValue;
+import com.github.silent.samurai.speedy.interfaces.backend.RowReader;
+import com.github.silent.samurai.speedy.interfaces.metadata.EntityMetadata;
+import com.github.silent.samurai.speedy.interfaces.metadata.FieldMetadata;
+import com.github.silent.samurai.speedy.interfaces.query.SpeedyQuery;
+import com.github.silent.samurai.speedy.interfaces.metadata.MetaModel;
+import com.github.silent.samurai.speedy.metadata.EntityBuilder;
+import com.github.silent.samurai.speedy.metadata.FieldBuilder;
+import com.github.silent.samurai.speedy.metadata.MetaModelBuilder;
+import com.github.silent.samurai.speedy.metadata.MetadataBuilder;
+import com.github.silent.samurai.speedy.models.SpeedyEntity;
+import com.github.silent.samurai.speedy.models.SpeedyEntityKey;
+import com.github.silent.samurai.speedy.utils.Speedy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Covers the batched `$expand` resolution: association targets are fetched one query per
+/// expansion level for the whole result set, instead of one query per row (the N+1 this replaces).
+class RecordToSpeedyBatchTest {
+
+    private EntityMetadata inventory;
+    private EntityMetadata product;
+    private EntityMetadata category;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MetaModelBuilder builder = MetadataBuilder.builder();
+        EntityBuilder categoryBuilder = builder.entity("Category");
+        EntityBuilder productBuilder = builder.entity("Product");
+        EntityBuilder inventoryBuilder = builder.entity("Inventory");
+
+        categoryBuilder.keyField("id", "ID", ColumnType.VARCHAR);
+        categoryBuilder.field("name", "NAME", ColumnType.VARCHAR);
+
+        productBuilder.keyField("id", "ID", ColumnType.VARCHAR);
+        productBuilder.field("name", "NAME", ColumnType.VARCHAR);
+        FieldBuilder categoryField = productBuilder.field("category", "CATEGORY_ID", ColumnType.VARCHAR);
+        categoryField.associateWith(categoryBuilder.keyFields().iterator().next());
+
+        inventoryBuilder.keyField("id", "ID", ColumnType.VARCHAR);
+        FieldBuilder productField = inventoryBuilder.field("product", "PRODUCT_ID", ColumnType.VARCHAR);
+        productField.associateWith(productBuilder.keyFields().iterator().next());
+
+        MetaModel metaModel = builder.build();
+        inventory = metaModel.findEntityMetadata("Inventory");
+        product = metaModel.findEntityMetadata("Product");
+        category = metaModel.findEntityMetadata("Category");
+    }
+
+    @Test
+    void expandingManyRowsFetchesTheAssociationOnce() throws Exception {
+        RecordingRowReader reader = new RecordingRowReader();
+        reader.addRow(categoryRow("c1", "Tools"));
+        reader.addRow(categoryRow("c2", "Toys"));
+
+        List<SpeedyEntity> rows = List.of(
+                productRow("p1", "Hammer", "c1"),
+                productRow("p2", "Saw", "c1"),
+                productRow("p3", "Kite", "c2"));
+
+        List<SpeedyEntity> result = new RecordToSpeedy(reader)
+                .fromRows(rows, product, Set.of("Category"));
+
+        assertEquals(1, reader.fkFetches.size(),
+                "expected one batched fetch for the Category expansion, got " + reader.fkFetches);
+        assertEquals(2, reader.fkFetches.get(0).size(),
+                "expected the two distinct category foreign keys in a single fetch");
+
+        assertEquals("Tools", expandedCategoryName(result.get(0)));
+        assertEquals("Tools", expandedCategoryName(result.get(1)));
+        assertEquals("Toys", expandedCategoryName(result.get(2)));
+    }
+
+    @Test
+    void nestedExpansionCostsOneFetchPerLevelNotPerRow() throws Exception {
+        RecordingRowReader reader = new RecordingRowReader();
+        reader.addRow(categoryRow("c1", "Tools"));
+        reader.addRow(categoryRow("c2", "Toys"));
+        reader.addRow(productRow("p1", "Hammer", "c1"));
+        reader.addRow(productRow("p2", "Saw", "c1"));
+        reader.addRow(productRow("p3", "Kite", "c2"));
+
+        List<SpeedyEntity> rows = List.of(
+                inventoryRow("i1", "p1"),
+                inventoryRow("i2", "p2"),
+                inventoryRow("i3", "p3"));
+
+        List<SpeedyEntity> result = new RecordToSpeedy(reader)
+                .fromRows(rows, inventory, Set.of("Product", "Product.Category"));
+
+        assertEquals(2, reader.fkFetches.size(),
+                "expected one fetch per expansion level (Product, then Category), got " + reader.fkFetches);
+
+        SpeedyEntity firstProduct = result.get(0).get(inventory.field("product")).asObject();
+        assertEquals("Hammer", firstProduct.get(product.field("name")).asText());
+        assertEquals("Tools", firstProduct.get(product.field("category")).asObject()
+                .get(category.field("name")).asText());
+    }
+
+    @Test
+    void rowsWithoutAForeignKeyResolveToNullAndAreLeftOutOfTheFetch() throws Exception {
+        RecordingRowReader reader = new RecordingRowReader();
+        reader.addRow(categoryRow("c1", "Tools"));
+
+        SpeedyEntity withoutFkColumn = new SpeedyEntity(product);
+        withoutFkColumn.put(product.field("id"), Speedy.from("p2"));
+        withoutFkColumn.put(product.field("name"), Speedy.from("Saw"));
+
+        SpeedyEntity withNullFk = productRow("p3", "Kite", "c9");
+        withNullFk.put(product.field("category"), Speedy.fromNull());
+
+        List<SpeedyEntity> rows = List.of(
+                productRow("p1", "Hammer", "c1"),
+                withoutFkColumn,
+                withNullFk);
+
+        List<SpeedyEntity> result = new RecordToSpeedy(reader)
+                .fromRows(rows, product, Set.of("Category"));
+
+        assertEquals(1, reader.fkFetches.size());
+        assertEquals(List.of(Speedy.from("c1")), reader.fkFetches.get(0),
+                "only the one resolvable foreign key should be fetched");
+
+        assertEquals("Tools", expandedCategoryName(result.get(0)));
+        assertTrue(result.get(1).get(product.field("category")).isNull(),
+                "a row whose foreign-key column was never selected should read as null");
+        assertTrue(result.get(2).get(product.field("category")).isNull(),
+                "a row whose foreign key is SQL NULL should read as null");
+    }
+
+    @Test
+    void aForeignKeyWithNoMatchingTargetResolvesToNull() throws Exception {
+        RecordingRowReader reader = new RecordingRowReader();
+        reader.addRow(categoryRow("c1", "Tools"));
+
+        List<SpeedyEntity> rows = List.of(
+                productRow("p1", "Hammer", "c1"),
+                productRow("p2", "Saw", "gone"));
+
+        List<SpeedyEntity> result = new RecordToSpeedy(reader)
+                .fromRows(rows, product, Set.of("Category"));
+
+        assertEquals("Tools", expandedCategoryName(result.get(0)));
+        assertTrue(result.get(1).get(product.field("category")).isNull(),
+                "a dangling foreign key should read as null, not drop the row");
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void aForeignKeyBatchLargerThanTheChunkSizeIsSplitAcrossFetches() throws Exception {
+        RecordingRowReader reader = new RecordingRowReader();
+        List<SpeedyEntity> rows = new ArrayList<>();
+        for (int i = 0; i < 620; i++) {
+            reader.addRow(categoryRow("c" + i, "Category " + i));
+            rows.add(productRow("p" + i, "Product " + i, "c" + i));
+        }
+
+        List<SpeedyEntity> result = new RecordToSpeedy(reader)
+                .fromRows(rows, product, Set.of("Category"));
+
+        assertEquals(2, reader.fkFetches.size(),
+                "620 distinct foreign keys should split into two fetches, got " + reader.fkFetches.size());
+        assertEquals(500, reader.fkFetches.get(0).size());
+        assertEquals(120, reader.fkFetches.get(1).size());
+
+        assertEquals("Category 0", expandedCategoryName(result.get(0)));
+        assertEquals("Category 619", expandedCategoryName(result.get(619)));
+    }
+
+    @Test
+    void anAssociationOutsideTheExpandSetIsNotFetchedAtAll() throws Exception {
+        RecordingRowReader reader = new RecordingRowReader();
+        reader.addRow(categoryRow("c1", "Tools"));
+
+        List<SpeedyEntity> result = new RecordToSpeedy(reader)
+                .fromRows(List.of(productRow("p1", "Hammer", "c1")), product, Set.of());
+
+        assertEquals(0, reader.fkFetches.size(), "a keys-only reference must not hit the backend");
+        SpeedyValue categoryRef = result.get(0).get(product.field("category"));
+        assertTrue(categoryRef.isObject());
+        assertEquals("c1", categoryRef.asObject().get(category.field("id")).asText());
+    }
+
+    private SpeedyEntity inventoryRow(String id, String productFk) throws Exception {
+        SpeedyEntity row = new SpeedyEntity(inventory);
+        row.put(inventory.field("id"), Speedy.from(id));
+        row.put(inventory.field("product"), Speedy.from(productFk));
+        return row;
+    }
+
+    private String expandedCategoryName(SpeedyEntity productEntity) throws Exception {
+        SpeedyValue value = productEntity.get(product.field("category"));
+        assertTrue(value.isObject(), "category should be expanded to an object");
+        return value.asObject().get(category.field("name")).asText();
+    }
+
+    private SpeedyEntity productRow(String id, String name, String categoryFk) throws Exception {
+        SpeedyEntity row = new SpeedyEntity(product);
+        row.put(product.field("id"), Speedy.from(id));
+        row.put(product.field("name"), Speedy.from(name));
+        row.put(product.field("category"), Speedy.from(categoryFk));
+        return row;
+    }
+
+    private SpeedyEntity categoryRow(String id, String name) throws Exception {
+        SpeedyEntity row = new SpeedyEntity(category);
+        row.put(category.field("id"), Speedy.from(id));
+        row.put(category.field("name"), Speedy.from(name));
+        return row;
+    }
+
+    /// Hand-written {@link RowReader} that serves rows from an in-memory table and records the
+    /// foreign-key batches it was asked for, so a test can assert how many round-trips happened.
+    private static final class RecordingRowReader implements RowReader {
+
+        private final List<SpeedyEntity> table = new ArrayList<>();
+        private final List<List<SpeedyValue>> fkFetches = new ArrayList<>();
+
+        void addRow(SpeedyEntity row) {
+            table.add(row);
+        }
+
+        @Override
+        public List<SpeedyEntity> selectByFks(FieldMetadata association, List<SpeedyValue> fkValues) {
+            fkFetches.add(List.copyOf(fkValues));
+            FieldMetadata targetField = association.getAssociatedFieldMetadata();
+            List<SpeedyEntity> matches = new ArrayList<>();
+            for (SpeedyEntity row : table) {
+                if (row.getMetadata().equals(association.getAssociationMetadata())
+                        && row.has(targetField)
+                        && fkValues.contains(row.get(targetField))) {
+                    matches.add(row);
+                }
+            }
+            return matches;
+        }
+
+        @Override
+        public List<SpeedyEntity> select(SpeedyQuery query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BigInteger count(SpeedyQuery query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<SpeedyEntity> selectByKeys(List<SpeedyEntityKey> keys) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/speedy-qp-jooq/src/main/java/com/github/silent/samurai/speedy/jooq/impl/query/JooqBackend.java
+++ b/speedy-qp-jooq/src/main/java/com/github/silent/samurai/speedy/jooq/impl/query/JooqBackend.java
@@ -100,22 +100,19 @@ public class JooqBackend implements SpeedyBackend {
     }
 
     @Override
-    public Optional<SpeedyEntity> selectByFk(FieldMetadata association, SpeedyEntity parentRow) throws SpeedyHttpException {
-        if (!parentRow.has(association)) {
-            return Optional.empty();
+    public List<SpeedyEntity> selectByFks(FieldMetadata association, List<SpeedyValue> fkValues) throws SpeedyHttpException {
+        if (fkValues.isEmpty()) {
+            return List.of();
         }
-        SpeedyValue fk = parentRow.get(association);
-        if (fk.isNull()) {
-            return Optional.empty();
+        // The FK is stored under the association field; re-encode each value (with the associated
+        // field's type) to query the related table.
+        FieldMetadata associatedField = association.getAssociatedFieldMetadata();
+        List<Object> fkColumnValues = new ArrayList<>(fkValues.size());
+        for (SpeedyValue fk : fkValues) {
+            fkColumnValues.add(converter.toColumnType(fk, associatedField));
         }
-        // The FK is stored under the association field; re-encode it (with the associated field's
-        // type) to query the related table.
-        Object fkColumnValue = converter.toColumnType(fk, association.getAssociatedFieldMetadata());
-        Optional<Record> associatedRecord = new JooqToJooqSql(dsl()).findByFK(association, fkColumnValue);
-        if (associatedRecord.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(toFlatEntity(associatedRecord.get(), association.getAssociationMetadata()));
+        Result<Record> result = new JooqToJooqSql(dsl()).findByFKs(association, fkColumnValues);
+        return wrap(result, association.getAssociationMetadata());
     }
 
     // ---- RowWriter ----

--- a/speedy-qp-jooq/src/main/java/com/github/silent/samurai/speedy/jooq/impl/query/JooqToJooqSql.java
+++ b/speedy-qp-jooq/src/main/java/com/github/silent/samurai/speedy/jooq/impl/query/JooqToJooqSql.java
@@ -7,11 +7,11 @@ import org.jooq.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
+import java.util.Collection;
 
 /// Executes FK-based association expansion queries.
-/// Used by {@link JooqBackend#selectByFk} (driven by the shared {@code RecordToSpeedy} walker)
-/// during $expand resolution.
+/// Used by {@link JooqBackend#selectByFks} (driven by the shared {@code RecordToSpeedy} walker)
+/// during $expand resolution — one query per expansion level, not per row.
 public class JooqToJooqSql {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JooqToJooqSql.class);
@@ -22,9 +22,10 @@ public class JooqToJooqSql {
         this.dslContext = dslContext;
     }
 
-    /// Fetches the single related row of {@code fieldMetadata}'s association whose key column equals
-    /// {@code fkColumnValue} (the parent row's already-converted foreign key); empty if none matches.
-    public Optional<Record> findByFK(FieldMetadata fieldMetadata, Object fkColumnValue) {
+    /// Fetches the related rows of {@code fieldMetadata}'s association whose key column matches any of
+    /// {@code fkColumnValues} (the parent rows' already-converted foreign keys), as one {@code IN}
+    /// query. Callers must pass a non-empty collection, already chunked to a size the backend accepts.
+    public Result<Record> findByFKs(FieldMetadata fieldMetadata, Collection<?> fkColumnValues) {
 
         EntityMetadata associationMetadata = fieldMetadata.getAssociationMetadata();
         FieldMetadata associationFieldMetadata = fieldMetadata.getAssociatedFieldMetadata();
@@ -35,14 +36,10 @@ public class JooqToJooqSql {
         SelectConditionStep<Record> query = dslContext
                 .select()
                 .from(table)
-                .where(field.eq(fkColumnValue));
+                .where(field.in(fkColumnValues));
 
-        LOGGER.info("expand query: {} ", query);
+        LOGGER.debug("expand query: {} ", query);
 
-        Result<Record> result = query.fetch();
-        if (result.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(result.get(0));
+        return query.fetch();
     }
 }

--- a/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/query/ExpandQueryCountTest.java
+++ b/speedy-test-app/src/test/java/com/github/silent/samurai/speedy/query/ExpandQueryCountTest.java
@@ -1,0 +1,202 @@
+package com.github.silent.samurai.speedy.query;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.silent.samurai.speedy.TestApplication;
+import com.github.silent.samurai.speedy.client.SpeedyQuery;
+import com.github.silent.samurai.speedy.enums.SpeedyEndpoint;
+import com.github.silent.samurai.speedy.interfaces.SpeedyConstants;
+import com.github.silent.samurai.speedy.utils.CommonUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/// Guards the `$expand` N+1 fix at the database boundary: association expansion must cost a fixed
+/// number of SQL statements regardless of how many rows the query returns.
+///
+/// Rather than pinning an exact statement count — which would break whenever unrelated bookkeeping
+/// queries change — this compares a one-row page against a many-row page of the same query. Under the
+/// per-row expansion this replaced, the wider page issued one extra statement per row.
+/// The capturing configuration is imported explicitly: a nested `@TestConfiguration` is only
+/// auto-detected when `@SpringBootTest` declares no `classes`.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = TestApplication.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(ExpandQueryCountTest.SqlCapturingConfig.class)
+class ExpandQueryCountTest {
+
+    private static final List<String> CAPTURED_SQL = Collections.synchronizedList(new ArrayList<>());
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void singleLevelExpandCostsTheSameNumberOfQueriesForOneRowAsForMany() throws Exception {
+        int oneRow = selectsIssuedBy(expandQuery(1), 1);
+        int manyRows = selectsIssuedBy(expandQuery(100), 2);
+
+        assertEquals(oneRow, manyRows,
+                "expanding more rows must not issue more queries; captured: " + CAPTURED_SQL);
+    }
+
+    @Test
+    void nestedExpandCostsTheSameNumberOfQueriesForOneRowAsForMany() throws Exception {
+        int oneRow = selectsIssuedBy(nestedExpandQuery(1), 1);
+        int manyRows = selectsIssuedBy(nestedExpandQuery(100), 2);
+
+        assertEquals(oneRow, manyRows,
+                "nested expansion must not issue more queries for more rows; captured: " + CAPTURED_SQL);
+    }
+
+    private JsonNode expandQuery(int pageSize) {
+        return SpeedyQuery.from("Product")
+                .expand("Category")
+                .pageNo(0)
+                .pageSize(pageSize)
+                .build();
+    }
+
+    private JsonNode nestedExpandQuery(int pageSize) {
+        return SpeedyQuery.from("Inventory")
+                .expand("Product")
+                .expand("Product.Category")
+                .pageNo(0)
+                .pageSize(pageSize)
+                .build();
+    }
+
+    /// Runs the query and returns how many SELECTs reached the database, asserting the response
+    /// really carried at least {@code minimumRows} rows — otherwise the comparison proves nothing.
+    private int selectsIssuedBy(JsonNode query, int minimumRows) throws Exception {
+        CAPTURED_SQL.clear();
+        MvcResult result = mvc.perform(MockMvcRequestBuilders
+                        .post(SpeedyConstants.URI + "/" + query.get("$from").asText() + "/" + SpeedyEndpoint.QUERY.suffix())
+                        .content(CommonUtil.json().writeValueAsString(query))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode payload = CommonUtil.json()
+                .readTree(result.getResponse().getContentAsString())
+                .get("payload");
+        assertTrue(payload.size() >= minimumRows,
+                "expected at least " + minimumRows + " rows to make the comparison meaningful, got " + payload.size());
+
+        synchronized (CAPTURED_SQL) {
+            int selects = (int) CAPTURED_SQL.stream()
+                    .filter(sql -> sql.trim().toLowerCase(Locale.ROOT).startsWith("select"))
+                    .count();
+            // Without this the comparison could pass by capturing nothing at all.
+            assertTrue(selects > 0, "no SQL was captured — the capturing DataSource is not in the wiring");
+            return selects;
+        }
+    }
+
+    @TestConfiguration
+    static class SqlCapturingConfig {
+
+        /// Wraps whatever {@link DataSource} the application context supplies, so every statement the
+        /// engine prepares is recorded without the production wiring knowing about it.
+        @Bean
+        static BeanPostProcessor sqlCapturingDataSource() {
+            return new BeanPostProcessor() {
+                @Override
+                public Object postProcessAfterInitialization(Object bean, String beanName) {
+                    if (bean instanceof DataSource dataSource && !(bean instanceof CapturingDataSource)) {
+                        return new CapturingDataSource(dataSource);
+                    }
+                    return bean;
+                }
+            };
+        }
+    }
+
+    private record CapturingDataSource(DataSource delegate) implements DataSource {
+
+        private static Connection capturing(Connection connection) {
+            return (Connection) Proxy.newProxyInstance(
+                    CapturingDataSource.class.getClassLoader(),
+                    new Class<?>[]{Connection.class},
+                    (proxy, method, args) -> {
+                        if (method.getName().startsWith("prepare") && args != null
+                                && args.length > 0 && args[0] instanceof String sql) {
+                            CAPTURED_SQL.add(sql);
+                        }
+                        try {
+                            return method.invoke(connection, args);
+                        } catch (InvocationTargetException e) {
+                            throw e.getCause();
+                        }
+                    });
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return capturing(delegate.getConnection());
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return capturing(delegate.getConnection(username, password));
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return delegate.getLogWriter();
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {
+            delegate.setLogWriter(out);
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {
+            delegate.setLoginTimeout(seconds);
+        }
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return delegate.getLoginTimeout();
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return delegate.unwrap(iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return delegate.isWrapperFor(iface);
+        }
+    }
+}


### PR DESCRIPTION
Closes #144.

> **Base branch:** this targets `test/openapi-key-type-preservation`, not `main`. The change rewrites `JooqToJooqSql.findByFK`, whose current form comes from `50c0c2d0` ("Fix $expand query building the wrong table identifier on MySQL") — a commit that is on that branch but not yet on `main`. Retargeting to `main` would drop that fix.

## Problem

Expanding a to-one association resolved one row at a time. `RecordToSpeedy` recursed depth-first per row and called `selectByFk` inside the per-row loop, and the jOOQ backend turned each call into its own `SELECT ... WHERE fk = ?`. A page of N rows expanding M levels cost O(N × M) queries.

## Change

Walk the result set breadth-first. Every row at one position in the entity tree is enriched together, so the complete set of foreign keys for the next level is known before that level is fetched. Each expansion level now costs one fetch for the whole page, and rows sharing a foreign key share the resolved target.

A depth-first walk cannot batch: row 2's foreign key is not read until row 1 has already been resolved to full depth.

- `RowReader.selectByFk(association, row)` → `selectByFks(association, values)`. Port surface is unchanged in size.
- The fetch stays keyed on the association's own foreign-key column (`WHERE fk_column IN (...)`) rather than the target's primary key. This keeps resolution semantics identical, including for the case where a target's primary key is composite — batching by primary key would have thrown there, where the per-row fetch did not.
- Key batches are chunked at 500. The previous single-key fetch never approached backend `IN`-list limits; a batched one can, and the default `maxPageSize` is 1000 with the URI path allowing more.
- `fromRow` is now a one-element wrapper over `fromRows`, so there is a single code path.

Behaviour deliberately preserved: an absent foreign-key column (`$select` that omits it), a SQL `NULL` foreign key, and a dangling foreign key all resolve to null exactly as before.

## Effect

Captured at the JDBC boundary against the test app:

| Query | Before | After |
| --- | ---: | ---: |
| `Product`, `$expand=Category` | 9 | 3 |
| `Inventory`, `$expand=Product,Product.Category` | 22 | 4 |

The "before" figures come from running the new `ExpandQueryCountTest` against the previous per-row mapping; the captured SQL showed the N+1 signature directly, alternating `PRODUCTS`/`CATEGORIES` `IN (?)` once per row.

## Tests

`RecordToSpeedyBatchTest` (speedy-core, hand-written `RowReader` fake): one fetch per level, distinct-key deduplication, nested expansion, absent/null/dangling foreign keys, chunk splitting, and no fetch at all for a keys-only reference.

`ExpandQueryCountTest` (speedy-test-app, real jOOQ/H2): asserts a one-row page and a many-row page of the same query issue the same number of SELECTs, rather than pinning an exact count that unrelated bookkeeping queries would break.

Each test was verified to fail against a deliberately broken implementation — shrinking the chunk size, dropping the null-foreign-key guard, recursing per target instead of per level, and removing the null assignment each broke exactly the intended assertion. That check also caught `ExpandQueryCountTest` initially passing while capturing no SQL at all: a nested `@TestConfiguration` is only auto-detected when `@SpringBootTest` declares no `classes`, so it now uses an explicit `@Import` and asserts the capture observed something.

Full reactor build is green.

## Follow-up

#145 tracks multi-column foreign keys, which would let associations target composite-primary-key entities. That is a pre-existing limitation — such a mapping needs `@JoinColumns`, which `JpaMetaModelProcessorV2.findDbColumnName` rejects at startup — and is not affected either way by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
